### PR TITLE
Fix build_windows.sh

### DIFF
--- a/build_windows.sh
+++ b/build_windows.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 ./configure \
+	--python=python2 \
 	--enable-debug \
 	--extra-cflags="-march=native -g3 -O0 -Wno-error" \
 	--target-list=i386-softmmu \


### PR DESCRIPTION
Build guide is also missing 2 packages that are needed for the 2.X rebase.
pacman -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pixman