### PR TITLE
WIP: do not include glew.h and gl.h twice

### DIFF
--- a/hw/xbox/nv2a/gl/gloffscreen.h
+++ b/hw/xbox/nv2a/gl/gloffscreen.h
@@ -41,10 +41,12 @@
 #include <GL/gl.h>
 #include <GL/wglext.h>
 #else                                  /* Assume GLX */
+#ifndef __gl_h_                        /* gloffscreen_wgl.c calls them first */
 #include <GL/glew.h>
 #include <GL/glx.h>
 #include <GL/glxext.h>
 #include <GL/gl.h>
+#endif
 #endif
 
 /* Used to hold data for the OpenGL context */


### PR DESCRIPTION
`gloffscreen_wgl.c` includes `glew.h` and `gl.h` then includes `gloffscreen.h` that includes `glew.h` and `gl.h` again.