### PR TITLE
fix `ARRAY_SIZE` gcc warning: "comparison is always false due to limi…

### DIFF
--- a/include/qemu/osdep.h
+++ b/include/qemu/osdep.h
@@ -248,8 +248,7 @@ extern int daemon(int, int);
 #define QEMU_IS_ARRAY(x) (!__builtin_types_compatible_p(typeof(x), \
                                                         typeof(&(x)[0])))
 #ifndef ARRAY_SIZE
-#define ARRAY_SIZE(x) ((sizeof(x) / sizeof((x)[0])) + \
-                       QEMU_BUILD_BUG_ON_ZERO(!QEMU_IS_ARRAY(x)))
+#define ARRAY_SIZE(x) ((sizeof(x) / sizeof(*(x))))
 #endif
 
 int qemu_daemon(int nochdir, int noclose);


### PR DESCRIPTION
…ted range of data type"

This patch fixes these GCC warnings:
```
xqemu/hw/xbox/nv2a/nv2a_pgraph.c:2547:37: warning: comparison is always false due to limited range of data type [-Wtype-limits]
         if (nmethod != 0 && nmethod < ARRAY_SIZE(nv2a_method_names)) {
                                     ^
xqemu/hw/xbox/nv2a/nv2a.c:252:19: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
         if (naddr < ARRAY_SIZE(nv2a_reg_names) && nv2a_reg_names[naddr]) {
                   ^
xqemu/hw/xbox/nv2a/nv2a.c:268:19: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
         if (naddr < ARRAY_SIZE(nv2a_reg_names) && nv2a_reg_names[naddr]) {
                   ^
```