### PR TITLE
Build scripts: have them return the same error as make on failure

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-set -e
-set -x
+
+set -e # exit if a command fails
+set -x # Print commands
+set -o pipefail # Will return the exit status of make if it fails
+
 ./configure \
 	--enable-debug \
 	--extra-cflags="-march=native -g -O0 -Wno-error=redundant-decls -Wno-error=unused-but-set-variable -DXBOX=1" \
@@ -24,5 +27,5 @@ set -x
 	--disable-spice \
 	--disable-user \
 
-time make -j4 | tee build.log
+time make -j4 2>&1 | tee build.log
 

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-set -e
-set -x
+
+set -e # exit if a command fails
+set -x # Print commands
+set -o pipefail # Will return the exit status of make if it fails
+
 ./configure \
 	--enable-debug \
 	--extra-cflags="-march=native -g -O0 -DXBOX=1" \
@@ -22,4 +25,4 @@ set -x
 	--disable-spice \
 	--disable-user \
 
-time make -j4 | tee build.log
+time make -j4 2>&1 | tee build.log

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-set -e
-set -x
+
+set -e # exit if a command fails
+set -x # Print commands
+set -o pipefail # Will return the exit status of make if it fails
+
 ./configure \
 	--python=python2 \
 	--enable-debug \
@@ -24,7 +27,7 @@ set -x
 	--disable-user \
 	--disable-opengl \
 
-time make -j4 | tee build.log
+time make -j4 2>&1 | tee build.log
 
 mkdir -p dist
 cp i386-softmmu/qemu-system-i386.exe dist/xqemu.exe


### PR DESCRIPTION
This is done trough the pipefail option, that returns the first-nonzero
return value when programs are piped together.
This commit also succinctly comments the other options used.

I am not too happy with the amount of code duplication there. Couldn't the build options be saved somewhere else, or even in the same script which would autodetect the platform?