### PR TITLE
nv2a: Recycle FIFO command queue memory

### DIFF
--- a/hw/xbox/nv2a/nv2a.h
+++ b/hw/xbox/nv2a/nv2a.h
@@ -348,10 +348,13 @@ typedef struct Cache1State {
     enum FIFOEngine last_engine;
 
     /* The actual command queue */
+    QemuSpin alloc_lock;
     QemuMutex cache_lock;
     QemuCond cache_cond;
     QSIMPLEQ_HEAD(, CacheEntry) cache;
     QSIMPLEQ_HEAD(, CacheEntry) working_cache;
+    QSIMPLEQ_HEAD(, CacheEntry) available_entries;
+    QSIMPLEQ_HEAD(, CacheEntry) retired_entries;
 } Cache1State;
 
 typedef struct ChannelControl {


### PR DESCRIPTION
This patch adds an additional "retired" queue in which FIFO command
entry objects are placed after execution. This queue of objects is then
returned to the pusher's new "available" queue for re-use.

This improves the performance of the system by avoiding the costly
overhead associated with the general-purpose use of `malloc` and `free`
for previous allocation of FIFO command queue objects.

Resolves #54, but TBH performance improvement is *visibly* minor, compared to our other slowdowns (#50).

I think there is still a lot of room to optimize this puller/pusher setup. But this is pretty low-hanging fruit and provides good returns, so let's leave more architectural changes for another PR.