### PR TITLE
Add SDL flags and libs to objects which use it

### DIFF
--- a/hw/xbox/Makefile.objs
+++ b/hw/xbox/Makefile.objs
@@ -10,3 +10,6 @@ obj-y += chihiro-usb.o
 
 obj-y += dsp/
 obj-y += nv2a/
+
+xid-sdl.o-cflags := $(SDL_CFLAGS)
+xid-sdl.o-libs := $(SDL_LIBS)

--- a/hw/xbox/dsp/Makefile.objs
+++ b/hw/xbox/dsp/Makefile.objs
@@ -1,1 +1,5 @@
 obj-y += dsp.o dsp_cpu.o dsp_dma.o
+
+# dsp_cpu.c uses SDL_GetTicks()
+dsp_cpu.o-cflags := $(SDL_CFLAGS)
+dsp_cpu.o-libs := $(SDL_LIBS)


### PR DESCRIPTION
When I tried to use x86_64 linux in XQEMU (to debug input issues) I had trouble with SDL not being linked to XID-SDL. The fix in Makefile.objs solved that problem.

Also, the DSP code uses `SDL_GetTicks()` if `#ifdef DSP_COUNT_IPS` is true.
Probably because of that check, I did not get errors about dsp_cpu.o.
I still decided to add a "fix" for it.
Not sure if using the SDL timing code in the DSP is a good idea. QEMU has platform independent timers for various virtual and wall-clock-time situations. We should review this.

Purely as a note: The nv2a_pgraph code would *also* have some SDL dependency in the method handler for `NV097_FLIP_STALL`. However, that is in an `#if 0` block marked with `// HACK HACK HACK`. As that code is always disabled I did not add the SDL flags / lib there.
Probably worth reviewing that instance anyway.

Ideally this change has no effects during normal XQEMU use. It's merely a cleanup and build fix for special use-cases.