### PR TITLE
Perform some cleanup on Xbox code

### DIFF
--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -135,7 +135,7 @@ DEFINE_PROTO(pcrtc)
 DEFINE_PROTO(prmcio)
 DEFINE_PROTO(pramdac)
 DEFINE_PROTO(prmdio)
-DEFINE_PROTO(pramin)
+// DEFINE_PROTO(pramin)
 DEFINE_PROTO(user)
 
 #undef DEFINE_PROTO

--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -113,34 +113,6 @@ void *nv_dma_map(NV2AState *d, hwaddr dma_obj_address, hwaddr *len)
     return d->vram_ptr + dma.address;
 }
 
-#define STUB 0
-
-#if STUB
-void *pfifo_puller_thread(void *opaque) { return NULL; }
-void pgraph_init(NV2AState *d){}
-static void pfifo_run_pusher(NV2AState *d){}
-void pgraph_destroy(PGRAPHState *pg){}
-static uint8_t cliptobyte(int x)
-{
-    return (uint8_t)((x < 0) ? 0 : ((x > 255) ? 255 : x));
-}
-static void convert_yuy2_to_rgb(const uint8_t *line, unsigned int ix,
-                                uint8_t *r, uint8_t *g, uint8_t* b) {
-    int c, d, e;
-    c = (int)line[ix * 2] - 16;
-    if (ix % 2) {
-        d = (int)line[ix * 2 - 1] - 128;
-        e = (int)line[ix * 2 + 1] - 128;
-    } else {
-        d = (int)line[ix * 2 + 1] - 128;
-        e = (int)line[ix * 2 + 3] - 128;
-    }
-    *r = cliptobyte((298 * c + 409 * e + 128) >> 8);
-    *g = cliptobyte((298 * c - 100 * d - 208 * e + 128) >> 8);
-    *b = cliptobyte((298 * c + 516 * d + 128) >> 8);
-}
-#endif
-
 #define DEFINE_PROTO(prefix) \
     uint64_t prefix ## _read(void *opaque, hwaddr addr, unsigned int size); \
     void prefix ## _write(void *opaque, hwaddr addr, uint64_t val, unsigned int size);
@@ -171,10 +143,8 @@ DEFINE_PROTO(user)
 #include "nv2a_pbus.c"
 #include "nv2a_pcrtc.c"
 #include "nv2a_pfb.c"
-#if !STUB
 #include "nv2a_pgraph.c"
 #include "nv2a_pfifo.c"
-#endif
 #include "nv2a_pmc.c"
 #include "nv2a_pramdac.c"
 #include "nv2a_prmcio.c"
@@ -183,32 +153,6 @@ DEFINE_PROTO(user)
 #include "nv2a_pvideo.c"
 #include "nv2a_stubs.c"
 #include "nv2a_user.c"
-
-#if STUB
-void pgraph_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
-{
-    reg_log_write(NV_PGRAPH, addr, val);
-}
-
-uint64_t pgraph_read(void *opaque, 
-                                   hwaddr addr, unsigned int size)
-{
-    reg_log_read(NV_PGRAPH, addr, 0);
-    return 0;
-}
-
-void pfifo_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
-{
-    reg_log_write(NV_PFIFO, addr, val);
-}
-
-uint64_t pfifo_read(void *opaque, 
-                                   hwaddr addr, unsigned int size)
-{
-    reg_log_read(NV_PFIFO, addr, 0);
-    return 0;
-}
-#endif
 
 const struct NV2ABlockInfo blocktable[] = {
 

--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -655,18 +655,6 @@ static void pgraph_method(NV2AState *d,
         break;
     }
     case NV097_FLIP_STALL:
-#if 0
-        // HACK HACK HACK
-        glBindFramebuffer(GL_READ_FRAMEBUFFER, pg->gl_framebuffer);
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-        glBlitFramebuffer(0, 0, 640, 480, 0, 0, 640, 480, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-        SDL_GL_SwapWindow(d->sdl_window); // ugh
-        assert(glGetError() == GL_NO_ERROR);
-        glBindFramebuffer(GL_READ_FRAMEBUFFER, pg->gl_framebuffer);
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, pg->gl_framebuffer);
-        glBindFramebuffer(GL_FRAMEBUFFER, pg->gl_framebuffer);
-        // HACK HACK HACK
-#endif
         pgraph_update_surface(d, false, true, true);
 
         while (true) {

--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -261,12 +261,7 @@ static const SurfaceColorFormatInfo kelvin_surface_color_format_map[] = {
         {4, GL_RGBA8, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV},
 };
 
-uint64_t pgraph_read(void *opaque, hwaddr addr, unsigned int size);
-void pgraph_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size);
-
-static void pgraph_context_switch(NV2AState *d, unsigned int channel_id);
 static void pgraph_set_context_user(NV2AState *d, uint32_t val);
-static void pgraph_wait_fifo_access(NV2AState *d);
 static void pgraph_method_log(unsigned int subchannel, unsigned int graphics_class, unsigned int method, uint32_t parameter);
 static void pgraph_allocate_inline_buffer_vertices(PGRAPHState *pg, unsigned int attr);
 static void pgraph_finish_inline_buffer_vertex(PGRAPHState *pg);
@@ -440,10 +435,10 @@ void pgraph_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
     qemu_mutex_unlock(&d->pgraph.lock);
 }
 
-static void pgraph_method(NV2AState *d,
-                          unsigned int subchannel,
-                          unsigned int method,
-                          uint32_t parameter)
+void pgraph_method(NV2AState *d,
+                   unsigned int subchannel,
+                   unsigned int method,
+                   uint32_t parameter)
 {
     int i;
     GraphicsSubchannel *subchannel_data;
@@ -2311,7 +2306,7 @@ static void pgraph_method(NV2AState *d,
             if (parameter & NV097_CLEAR_SURFACE_STENCIL) {
                 gl_mask |= GL_STENCIL_BUFFER_BIT;
                 glStencilMask(0xff);
-                glClearStencil(gl_clear_stencil);            
+                glClearStencil(gl_clear_stencil);
             }
         }
         if (write_color) {
@@ -2516,7 +2511,7 @@ static void pgraph_method(NV2AState *d,
 }
 
 
-static void pgraph_context_switch(NV2AState *d, unsigned int channel_id)
+void pgraph_context_switch(NV2AState *d, unsigned int channel_id)
 {
     bool valid;
     valid = d->pgraph.channel_valid && d->pgraph.channel_id == channel_id;
@@ -2540,7 +2535,7 @@ static void pgraph_context_switch(NV2AState *d, unsigned int channel_id)
     }
 }
 
-static void pgraph_wait_fifo_access(NV2AState *d) {
+void pgraph_wait_fifo_access(NV2AState *d) {
     while (!d->pgraph.fifo_access) {
         qemu_cond_wait(&d->pgraph.fifo_access_cond, &d->pgraph.lock);
     }

--- a/hw/xbox/nv2a/nv2a_prmcio.c
+++ b/hw/xbox/nv2a/nv2a_prmcio.c
@@ -20,8 +20,7 @@
  */
 
 /* PRMCIO - aliases VGA CRTC and attribute controller registers */
-uint64_t prmcio_read(void *opaque,
-                                  hwaddr addr, unsigned int size)
+uint64_t prmcio_read(void *opaque, hwaddr addr, unsigned int size)
 {
     NV2AState *d = opaque;
     uint64_t r = vga_ioport_read(&d->vga, addr);
@@ -29,8 +28,8 @@ uint64_t prmcio_read(void *opaque,
     reg_log_read(NV_PRMCIO, addr, r);
     return r;
 }
-void prmcio_write(void *opaque, hwaddr addr,
-                               uint64_t val, unsigned int size)
+
+void prmcio_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
 {
     NV2AState *d = opaque;
 

--- a/hw/xbox/nv2a/nv2a_prmvio.c
+++ b/hw/xbox/nv2a/nv2a_prmvio.c
@@ -20,8 +20,7 @@
  */
 
 /* PRMVIO - aliases VGA sequencer and graphics controller registers */
-uint64_t prmvio_read(void *opaque,
-                                  hwaddr addr, unsigned int size)
+uint64_t prmvio_read(void *opaque, hwaddr addr, unsigned int size)
 {
     NV2AState *d = opaque;
     uint64_t r = vga_ioport_read(&d->vga, addr);
@@ -29,12 +28,11 @@ uint64_t prmvio_read(void *opaque,
     reg_log_read(NV_PRMVIO, addr, r);
     return r;
 }
-void prmvio_write(void *opaque, hwaddr addr,
-                               uint64_t val, unsigned int size)
+
+void prmvio_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
 {
     NV2AState *d = opaque;
 
     reg_log_write(NV_PRMVIO, addr, val);
-
     vga_ioport_write(&d->vga, addr, val);
 }

--- a/hw/xbox/nv2a/nv2a_pvideo.c
+++ b/hw/xbox/nv2a/nv2a_pvideo.c
@@ -29,8 +29,7 @@ static void pvideo_vga_invalidate(NV2AState *d)
     vga_invalidate_scanlines(&d->vga, y1, y2);
 }
 
-uint64_t pvideo_read(void *opaque,
-                            hwaddr addr, unsigned int size)
+uint64_t pvideo_read(void *opaque, hwaddr addr, unsigned int size)
 {
     NV2AState *d = opaque;
 
@@ -48,8 +47,7 @@ uint64_t pvideo_read(void *opaque,
     return r;
 }
 
-void pvideo_write(void *opaque, hwaddr addr,
-                         uint64_t val, unsigned int size)
+void pvideo_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
 {
     NV2AState *d = opaque;
 

--- a/hw/xbox/nv2a/nv2a_stubs.c
+++ b/hw/xbox/nv2a/nv2a_stubs.c
@@ -19,100 +19,29 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
-uint64_t prma_read(void *opaque,
-                                  hwaddr addr, unsigned int size)
-{
-    reg_log_read(NV_PRMA, addr, 0);
-    return 0;
-}
-void prma_write(void *opaque, hwaddr addr,
-                               uint64_t val, unsigned int size)
-{
-    reg_log_write(NV_PRMA, addr, val);
-}
+#define DEFINE_STUB(name, region_id) \
+    uint64_t name ## _read(void *opaque, \
+                           hwaddr addr, \
+                           unsigned int size) \
+    { \
+        reg_log_read(region_id, addr, 0); \
+        return 0; \
+    } \
+    void name ## _write(void *opaque, \
+                        hwaddr addr, \
+                        uint64_t val, \
+                        unsigned int size) \
+    { \
+        reg_log_write(region_id, addr, val); \
+    } \
 
-uint64_t pcounter_read(void *opaque,
-                                  hwaddr addr, unsigned int size)
-{
-    reg_log_read(NV_PCOUNTER, addr, 0);
-    return 0;
-}
-void pcounter_write(void *opaque, hwaddr addr,
-                               uint64_t val, unsigned int size)
-{
-    reg_log_write(NV_PCOUNTER, addr, val);
-}
+DEFINE_STUB(prma, NV_PRMA)
+DEFINE_STUB(pcounter, NV_PCOUNTER)
+DEFINE_STUB(pvpe, NV_PVPE)
+DEFINE_STUB(ptv, NV_PTV)
+DEFINE_STUB(prmfb, NV_PRMFB)
+DEFINE_STUB(prmdio, NV_PRMDIO)
+DEFINE_STUB(pstraps, NV_PSTRAPS)
+// DEFINE_STUB(pramin, NV_PRAMIN)
 
-uint64_t pvpe_read(void *opaque,
-                                  hwaddr addr, unsigned int size)
-{
-    reg_log_read(NV_PVPE, addr, 0);
-    return 0;
-}
-void pvpe_write(void *opaque, hwaddr addr,
-                               uint64_t val, unsigned int size)
-{
-    reg_log_write(NV_PVPE, addr, val);
-}
-
-uint64_t ptv_read(void *opaque,
-                                  hwaddr addr, unsigned int size)
-{
-    reg_log_read(NV_PTV, addr, 0);
-    return 0;
-}
-void ptv_write(void *opaque, hwaddr addr,
-                               uint64_t val, unsigned int size)
-{
-    reg_log_write(NV_PTV, addr, val);
-}
-
-uint64_t prmfb_read(void *opaque,
-                                  hwaddr addr, unsigned int size)
-{
-    reg_log_read(NV_PRMFB, addr, 0);
-    return 0;
-}
-void prmfb_write(void *opaque, hwaddr addr,
-                               uint64_t val, unsigned int size)
-{
-    reg_log_write(NV_PRMFB, addr, val);
-}
-
-uint64_t prmdio_read(void *opaque,
-                                  hwaddr addr, unsigned int size)
-{
-    reg_log_read(NV_PRMDIO, addr, 0);
-    return 0;
-}
-void prmdio_write(void *opaque, hwaddr addr,
-                               uint64_t val, unsigned int size)
-{
-    reg_log_write(NV_PRMDIO, addr, val);
-}
-
-uint64_t pstraps_read(void *opaque,
-                                  hwaddr addr, unsigned int size)
-{
-    reg_log_read(NV_PSTRAPS, addr, 0);
-    return 0;
-}
-void pstraps_write(void *opaque, hwaddr addr,
-                               uint64_t val, unsigned int size)
-{
-    reg_log_write(NV_PSTRAPS, addr, val);
-}
-
-/* PRAMIN - RAMIN access */
-/*
-uint64_t pramin_read(void *opaque,
-                                 hwaddr addr, unsigned int size)
-{
-    NV2A_DPRINTF("nv2a PRAMIN: read [0x%" HWADDR_PRIx "] -> 0x%" HWADDR_PRIx "\n", addr, r);
-    return 0;
-}
-void pramin_write(void *opaque, hwaddr addr,
-                              uint64_t val, unsigned int size)
-{
-    NV2A_DPRINTF("nv2a PRAMIN: [0x%" HWADDR_PRIx "] = 0x%02llx\n", addr, val);
-}*/
+#undef DEFINE_STUB

--- a/hw/xbox/nvnet.c
+++ b/hw/xbox/nvnet.c
@@ -63,8 +63,8 @@ enum {
 #       define NVREG_IRQ_TX1          0x0100
 #       define NVREG_IRQMASK_WANTED_1 0x005f
 #       define NVREG_IRQMASK_WANTED_2 0x0147
-#       define NVREG_IRQ_UNKNOWN      (~(NVREG_IRQ_RX|NVREG_IRQ_RX_NOBUF|\
-    NVREG_IRQ_TX_ERR|NVREG_IRQ_TX2|NVREG_IRQ_TIMER|NVREG_IRQ_LINK|\
+#       define NVREG_IRQ_UNKNOWN      (~(NVREG_IRQ_RX | NVREG_IRQ_RX_NOBUF | \
+    NVREG_IRQ_TX_ERR | NVREG_IRQ_TX2 | NVREG_IRQ_TIMER | NVREG_IRQ_LINK | \
     NVREG_IRQ_TX1))
     NvRegUnknownSetupReg6 = 0x008,
 #       define NVREG_UNKSETUP6_VAL 3
@@ -118,7 +118,7 @@ enum {
 #       define NVREG_LINKSPEED_100   100
 #       define NVREG_LINKSPEED_1000  1000
     NvRegUnknownSetupReg5 = 0x130,
-#       define NVREG_UNKSETUP5_BIT31 (1<<31)
+#       define NVREG_UNKSETUP5_BIT31 (1 << 31)
     NvRegUnknownSetupReg3 = 0x134,
 #       define NVREG_UNKSETUP3_VAL1 0x200010
     NvRegUnknownSetupReg8 = 0x13C,
@@ -145,7 +145,7 @@ enum {
 #       define NVREG_ADAPTCTL_RUNNING  0x100000
 #       define NVREG_ADAPTCTL_PHYSHIFT 24
     NvRegMIISpeed = 0x18c,
-#       define NVREG_MIISPEED_BIT8 (1<<8)
+#       define NVREG_MIISPEED_BIT8 (1 << 8)
 #       define NVREG_MIIDELAY  5
     NvRegMIIControl = 0x190,
 #       define NVREG_MIICTL_INUSE 0x10000
@@ -166,9 +166,9 @@ enum {
     NvRegPatternCRC = 0x204,
     NvRegPatternMask = 0x208,
     NvRegPowerCap = 0x268,
-#       define NVREG_POWERCAP_D3SUPP (1<<30)
-#       define NVREG_POWERCAP_D2SUPP (1<<26)
-#       define NVREG_POWERCAP_D1SUPP (1<<25)
+#       define NVREG_POWERCAP_D3SUPP (1 << 30)
+#       define NVREG_POWERCAP_D2SUPP (1 << 26)
+#       define NVREG_POWERCAP_D1SUPP (1 << 25)
     NvRegPowerState = 0x26c,
 #       define NVREG_POWERSTATE_POWEREDUP 0x8000
 #       define NVREG_POWERSTATE_VALID     0x0100
@@ -179,28 +179,28 @@ enum {
 #       define NVREG_POWERSTATE_D3        0x0003
 };
 
-#define NV_TX_LASTPACKET      (1<<0)
-#define NV_TX_RETRYERROR      (1<<3)
-#define NV_TX_LASTPACKET1     (1<<8)
-#define NV_TX_DEFERRED        (1<<10)
-#define NV_TX_CARRIERLOST     (1<<11)
-#define NV_TX_LATECOLLISION   (1<<12)
-#define NV_TX_UNDERFLOW       (1<<13)
-#define NV_TX_ERROR           (1<<14)
-#define NV_TX_VALID           (1<<15)
-#define NV_RX_DESCRIPTORVALID (1<<0)
-#define NV_RX_MISSEDFRAME     (1<<1)
-#define NV_RX_SUBSTRACT1      (1<<3)
-#define NV_RX_BIT4            (1<<4)
-#define NV_RX_ERROR1          (1<<7)
-#define NV_RX_ERROR2          (1<<8)
-#define NV_RX_ERROR3          (1<<9)
-#define NV_RX_ERROR4          (1<<10)
-#define NV_RX_CRCERR          (1<<11)
-#define NV_RX_OVERFLOW        (1<<12)
-#define NV_RX_FRAMINGERR      (1<<13)
-#define NV_RX_ERROR           (1<<14)
-#define NV_RX_AVAIL           (1<<15)
+#define NV_TX_LASTPACKET      (1 << 0)
+#define NV_TX_RETRYERROR      (1 << 3)
+#define NV_TX_LASTPACKET1     (1 << 8)
+#define NV_TX_DEFERRED        (1 << 10)
+#define NV_TX_CARRIERLOST     (1 << 11)
+#define NV_TX_LATECOLLISION   (1 << 12)
+#define NV_TX_UNDERFLOW       (1 << 13)
+#define NV_TX_ERROR           (1 << 14)
+#define NV_TX_VALID           (1 << 15)
+#define NV_RX_DESCRIPTORVALID (1 << 0)
+#define NV_RX_MISSEDFRAME     (1 << 1)
+#define NV_RX_SUBSTRACT1      (1 << 3)
+#define NV_RX_BIT4            (1 << 4)
+#define NV_RX_ERROR1          (1 << 7)
+#define NV_RX_ERROR2          (1 << 8)
+#define NV_RX_ERROR3          (1 << 9)
+#define NV_RX_ERROR4          (1 << 10)
+#define NV_RX_CRCERR          (1 << 11)
+#define NV_RX_OVERFLOW        (1 << 12)
+#define NV_RX_FRAMINGERR      (1 << 13)
+#define NV_RX_ERROR           (1 << 14)
+#define NV_RX_AVAIL           (1 << 15)
 
 /* Miscelaneous hardware related defines: */
 #define NV_PCI_REGSZ          0x270
@@ -224,7 +224,7 @@ enum {
 #define NV_WAKEUPMASKENTRIES  4
 
 /* General driver defaults */
-#define NV_WATCHDOG_TIMEO     (2*HZ)
+#define NV_WATCHDOG_TIMEO     (2 * HZ)
 #define DEFAULT_MTU           1500
 
 #define RX_RING               4
@@ -233,13 +233,13 @@ enum {
 #define TX_LIMIT_STOP         10
 #define TX_LIMIT_START        5
 
-/* rx/tx mac addr + type + vlan + align + slack*/
+/* rx / tx mac addr + type + vlan + align + slack*/
 #define RX_NIC_BUFSIZE        (DEFAULT_MTU + 64)
 /* even more slack */
 #define RX_ALLOC_BUFSIZE      (DEFAULT_MTU + 128)
 
-#define OOM_REFILL            (1+HZ/20)
-#define POLL_WAIT             (1+HZ/100)
+#define OOM_REFILL            (1 + HZ / 20)
+#define POLL_WAIT             (1 + HZ / 100)
 
 #define MII_READ      (-1)
 #define MII_PHYSID1   0x02    /* PHYS ID 1                   */
@@ -273,7 +273,7 @@ typedef struct NvNetState {
     NICState     *nic;
     NICConf      conf;
     MemoryRegion mmio, io;
-    uint8_t      regs[MMIO_SIZE/4];
+    uint8_t      regs[MMIO_SIZE / 4];
     uint32_t     phy_regs[6];
     uint8_t      tx_ring_index;
     uint8_t      tx_ring_size;
@@ -334,7 +334,7 @@ static void nvnet_set_link_status(NetClientState *nc);
 /* Interrupts */
 static void nvnet_update_irq(NvNetState *s);
 
-/* Packet Tx/Rx */
+/* Packet Tx / Rx */
 static void nvnet_send_packet(NvNetState *s,
     const uint8_t *buf, int size);
 static ssize_t nvnet_dma_packet_to_guest(NvNetState *s,
@@ -384,11 +384,11 @@ static uint32_t nvnet_get_reg(NvNetState *s, hwaddr addr, unsigned int size)
     switch (size) {
     case 4:
         assert((addr & 3) == 0); /* Unaligned register access. */
-        return ((uint32_t *)s->regs)[addr>>2];
+        return ((uint32_t *)s->regs)[addr >> 2];
 
     case 2:
         assert((addr & 1) == 0); /* Unaligned register access. */
-        return ((uint16_t *)s->regs)[addr>>1];
+        return ((uint16_t *)s->regs)[addr >> 1];
 
     case 1:
         return s->regs[addr];
@@ -407,12 +407,12 @@ static void nvnet_set_reg(NvNetState *s,
     switch (size) {
     case 4:
         assert((addr & 3) == 0); /* Unaligned register access. */
-        ((uint32_t *)s->regs)[addr>>2] = val;
+        ((uint32_t *)s->regs)[addr >> 2] = val;
         break;
 
     case 2:
         assert((addr & 1) == 0); /* Unaligned register access. */
-        ((uint16_t *)s->regs)[addr>>1] = (uint16_t)val;
+        ((uint16_t *)s->regs)[addr >> 1] = (uint16_t)val;
         break;
 
     case 1:
@@ -476,7 +476,7 @@ static int nvnet_mii_rw(NvNetState *s, uint64_t val)
 }
 
 /*******************************************************************************
- * MMIO Read/Write
+ * MMIO Read / Write
  ******************************************************************************/
 
 /*
@@ -532,8 +532,8 @@ static void nvnet_mmio_write(void *opaque, hwaddr addr,
     switch (addr) {
     case NvRegRingSizes:
         nvnet_set_reg(s, addr, val, size);
-        s->rx_ring_size = ((val >> NVREG_RINGSZ_RXSHIFT) & 0xffff)+1;
-        s->tx_ring_size = ((val >> NVREG_RINGSZ_TXSHIFT) & 0xffff)+1;
+        s->rx_ring_size = ((val >> NVREG_RINGSZ_RXSHIFT) & 0xffff) + 1;
+        s->tx_ring_size = ((val >> NVREG_RINGSZ_TXSHIFT) & 0xffff) + 1;
         break;
 
     case NvRegMIIData:
@@ -589,7 +589,7 @@ static const MemoryRegionOps nvnet_mmio_ops = {
 };
 
 /*******************************************************************************
- * Packet TX/RX
+ * Packet TX / RX
  ******************************************************************************/
 
 static void nvnet_send_packet(NvNetState *s, const uint8_t *buf, int size)
@@ -648,7 +648,7 @@ static ssize_t nvnet_dma_packet_to_guest(NvNetState *s,
         /* Read current ring descriptor */
         s->rx_ring_index %= s->rx_ring_size;
         dma_addr_t rx_ring_addr = nvnet_get_reg(s, NvRegRxRingPhysAddr, 4);
-        rx_ring_addr += s->rx_ring_index*sizeof(desc);
+        rx_ring_addr += s->rx_ring_index * sizeof(desc);
         pci_dma_read(&s->dev, rx_ring_addr, &desc, sizeof(desc));
         NVNET_DPRINTF("Looking at ring descriptor %d (0x%llx): ",
                       s->rx_ring_index, rx_ring_addr);
@@ -714,15 +714,15 @@ static ssize_t nvnet_dma_packet_from_guest(NvNetState *s)
         /* Transfer packet from guest memory */
         NVNET_DPRINTF("Sending packet...\n");
         pci_dma_read(&s->dev, desc.packet_buffer,
-                              s->txrx_dma_buf, desc.length+1);
-        nvnet_send_packet(s, s->txrx_dma_buf, desc.length+1);
+                              s->txrx_dma_buf, desc.length + 1);
+        nvnet_send_packet(s, s->txrx_dma_buf, desc.length + 1);
 
         /* Update descriptor */
         is_last_packet = desc.flags & NV_TX_LASTPACKET;
         desc.flags &= ~(NV_TX_VALID | NV_TX_RETRYERROR | NV_TX_DEFERRED |
             NV_TX_CARRIERLOST | NV_TX_LATECOLLISION | NV_TX_UNDERFLOW |
             NV_TX_ERROR);
-        desc.length = desc.length+5;
+        desc.length = desc.length + 5;
         pci_dma_write(&s->dev, tx_ring_addr, &desc, sizeof(desc));
 
         if (is_last_packet) {
@@ -764,7 +764,7 @@ static void nvnet_set_link_status(NetClientState *nc)
 }
 
 /*******************************************************************************
- * IO Read/Write
+ * IO Read / Write
  ******************************************************************************/
 
 static uint64_t nvnet_io_read(void *opaque, hwaddr addr, unsigned int size)
@@ -825,12 +825,12 @@ static void nvnet_realize(PCIDevice *pci_dev, Error **errp)
         object_get_typename(OBJECT(s)), dev->id, s);
     assert(s->nic);
 
-    s->regs[NvRegMacAddrA+0x00] = s->conf.macaddr.a[0];
-    s->regs[NvRegMacAddrA+0x01] = s->conf.macaddr.a[1];
-    s->regs[NvRegMacAddrA+0x02] = s->conf.macaddr.a[2];
-    s->regs[NvRegMacAddrA+0x03] = s->conf.macaddr.a[3];
-    s->regs[NvRegMacAddrB+0x00] = s->conf.macaddr.a[4];
-    s->regs[NvRegMacAddrB+0x01] = s->conf.macaddr.a[5];
+    s->regs[NvRegMacAddrA + 0x00] = s->conf.macaddr.a[0];
+    s->regs[NvRegMacAddrA + 0x01] = s->conf.macaddr.a[1];
+    s->regs[NvRegMacAddrA + 0x02] = s->conf.macaddr.a[2];
+    s->regs[NvRegMacAddrA + 0x03] = s->conf.macaddr.a[3];
+    s->regs[NvRegMacAddrB + 0x00] = s->conf.macaddr.a[4];
+    s->regs[NvRegMacAddrB + 0x01] = s->conf.macaddr.a[5];
 }
 
 static void nvnet_uninit(PCIDevice *dev)
@@ -881,14 +881,14 @@ static void hex_dump(FILE *f, const uint8_t *buf, int size)
         fprintf(f, "%08x ", i);
         for (j = 0; j < 16; j++) {
             if (j < len) {
-                fprintf(f, " %02x", buf[i+j]);
+                fprintf(f, " %02x", buf[i + j]);
             } else {
                 fprintf(f, "   ");
             }
         }
         fprintf(f, " ");
         for (j = 0; j < len; j++) {
-            c = buf[i+j];
+            c = buf[i + j];
             if (c < ' ' || c > '~') {
                 c = '.';
             }

--- a/hw/xbox/smbus_cx25871.c
+++ b/hw/xbox/smbus_cx25871.c
@@ -23,56 +23,48 @@
 #include "hw/i2c/smbus.h"
 #include "smbus.h"
 
-//#define DEBUG
+// #define DEBUG
+#ifdef DEBUG
+# define DPRINTF(format, ...) printf(format, ## __VA_ARGS__)
+#else
+# define DPRINTF(format, ...) do { } while (0)
+#endif
 
 typedef struct SMBusCX25871Device {
     SMBusDevice smbusdev;
-
     uint8_t registers[256];
 } SMBusCX25871Device;
 
 static void cx_quick_cmd(SMBusDevice *dev, uint8_t read)
 {
-#ifdef DEBUG
-    printf("cx_quick_cmd: addr=0x%02x read=%d\n", dev->i2c.address, read);
-#endif
+    DPRINTF("cx_quick_cmd: addr=0x%02x read=%d\n", dev->i2c.address, read);
 }
 
 static void cx_send_byte(SMBusDevice *dev, uint8_t val)
 {
-#ifdef DEBUG
-    printf("cx_send_byte: addr=0x%02x val=0x%02x\n",
-           dev->i2c.address, val);
-#endif
+    DPRINTF("cx_send_byte: addr=0x%02x val=0x%02x\n", dev->i2c.address, val);
 }
 
 static uint8_t cx_receive_byte(SMBusDevice *dev)
 {
-#ifdef DEBUG
-    printf("cx_receive_byte: addr=0x%02x\n",
-           dev->i2c.address);
-#endif
+    DPRINTF("cx_receive_byte: addr=0x%02x\n", dev->i2c.address);
     return 0;
 }
 
 static void cx_write_data(SMBusDevice *dev, uint8_t cmd, uint8_t *buf, int len)
 {
-    SMBusCX25871Device *cx = (SMBusCX25871Device *) dev;
-#ifdef DEBUG
-    printf("cx_write_byte: addr=0x%02x cmd=0x%02x val=0x%02x\n",
-           dev->i2c.address, cmd, buf[0]);
-#endif
+    SMBusCX25871Device *cx = (SMBusCX25871Device *)dev;
+    DPRINTF("cx_write_byte: addr=0x%02x cmd=0x%02x val=0x%02x\n",
+            dev->i2c.address, cmd, buf[0]);
 
     memcpy(cx->registers + cmd, buf, MIN(len, 256 - cmd));
 }
 
 static uint8_t cx_read_data(SMBusDevice *dev, uint8_t cmd, int n)
 {
-    SMBusCX25871Device *cx = (SMBusCX25871Device *) dev;
-    #ifdef DEBUG
-        printf("cx_read_data: addr=0x%02x cmd=0x%02x n=%d\n",
-               dev->i2c.address, cmd, n);
-    #endif
+    SMBusCX25871Device *cx = (SMBusCX25871Device *)dev;
+    DPRINTF("cx_read_data: addr=0x%02x cmd=0x%02x n=%d\n",
+            dev->i2c.address, cmd, n);
 
     return cx->registers[cmd];
 }

--- a/hw/xbox/smbus_xbox_smc.c
+++ b/hw/xbox/smbus_xbox_smc.c
@@ -26,7 +26,12 @@
 #include "sysemu/sysemu.h"
 #include "smbus.h"
 
-//#define DEBUG
+// #define DEBUG
+#ifdef DEBUG
+# define DPRINTF(format, ...) printf(format, ## __VA_ARGS__)
+#else
+# define DPRINTF(format, ...) do { } while (0)
+#endif
 
 /*
  * Hardware is a PIC16LC
@@ -77,35 +82,25 @@ typedef struct SMBusSMCDevice {
 
 static void smc_quick_cmd(SMBusDevice *dev, uint8_t read)
 {
-#ifdef DEBUG
-    printf("smc_quick_cmd: addr=0x%02x read=%d\n", dev->i2c.address, read);
-#endif
+    DPRINTF("smc_quick_cmd: addr=0x%02x read=%d\n", dev->i2c.address, read);
 }
 
 static void smc_send_byte(SMBusDevice *dev, uint8_t val)
 {
-#ifdef DEBUG
-    printf("smc_send_byte: addr=0x%02x val=0x%02x\n",
-           dev->i2c.address, val);
-#endif
+    DPRINTF("smc_send_byte: addr=0x%02x val=0x%02x\n", dev->i2c.address, val);
 }
 
 static uint8_t smc_receive_byte(SMBusDevice *dev)
 {
-#ifdef DEBUG
-    printf("smc_receive_byte: addr=0x%02x\n",
-           dev->i2c.address);
-#endif
+    DPRINTF("smc_receive_byte: addr=0x%02x\n", dev->i2c.address);
     return 0;
 }
 
 static void smc_write_data(SMBusDevice *dev, uint8_t cmd, uint8_t *buf, int len)
 {
     SMBusSMCDevice *smc = (SMBusSMCDevice *) dev;
-#ifdef DEBUG
-    printf("smc_write_byte: addr=0x%02x cmd=0x%02x val=0x%02x\n",
+    DPRINTF("smc_write_byte: addr=0x%02x cmd=0x%02x val=0x%02x\n",
            dev->i2c.address, cmd, buf[0]);
-#endif
 
     switch (cmd) {
     case SMC_REG_VER:
@@ -139,11 +134,9 @@ static void smc_write_data(SMBusDevice *dev, uint8_t cmd, uint8_t *buf, int len)
 
 static uint8_t smc_read_data(SMBusDevice *dev, uint8_t cmd, int n)
 {
-    SMBusSMCDevice *smc = (SMBusSMCDevice *) dev;
-    #ifdef DEBUG
-        printf("smc_read_data: addr=0x%02x cmd=0x%02x n=%d\n",
-               dev->i2c.address, cmd, n);
-    #endif
+    SMBusSMCDevice *smc = (SMBusSMCDevice *)dev;
+    DPRINTF("smc_read_data: addr=0x%02x cmd=0x%02x n=%d\n",
+            dev->i2c.address, cmd, n);
 
     switch (cmd) {
     case SMC_REG_VER:


### PR DESCRIPTION
This PR is to cleanup some of the Xbox-specific code, specifically.
- Removing dead code (Resolves #70)
- Eliminating some duplication through use of basic macros
- Ideally get all code passing through scripts/checkpatch.pl (I fixed some files during rebase, but there are more...)
- Additional cleanup tbd

## checkpatch.pl
Note: I'm not fixing up stuff we get from other places (e.g. wlgext.h), just our core Xbox stuff.

Many of our files are coming back clean now from checkpatch.pl. Still need to fixup:
- nv2a_pfifo.c
- nv2a_pgraph.c
- nv2a_shaders.c

checkpatch.pl will still complain about our usage of:
- `ERROR: use ctz32() instead of ffs()`
- C99 comment style (`// comment`)
- `#if 0`/`#endif` disabled code
- Lines with more than 80 characters

I've been using clang-format to do the extremely tedious bits, but it doesn't always get things right so I've had to selectively add the changes.