### PR TITLE
Fix copying of DLLs on Windows

### DIFF
--- a/get_deps.py
+++ b/get_deps.py
@@ -23,12 +23,12 @@ def main():
 		print('File exists with destination name')
 		sys.exit(1)
 		
-	has_cygpath = True
 	try:
 		subprocess.check_output(['cygpath', '--help'])
 	except OSError as err:
-		print("Couldn't execute cygpath (Reason: '%s'). Continuing without." % err)
-		has_cygpath = False
+		print("Couldn't execute cygpath (Reason: '%s')." % err)
+		print("Make sure you're using a recent version of MSYS2 and that it works correctly.")
+		sys.exit(1)
 
 	sout = subprocess.check_output(['ldd', args.prog])
 	for line in sout.splitlines():
@@ -37,10 +37,9 @@ def main():
 		if dll_name.startswith('???'):
 			print('Unknown DLL?')
 			continue
-		if has_cygpath:
-			# ldd on msys2 gives Unix-style paths, but Python wants them Windows-style
-			# If we have cygpath, convert the paths
-			dll_path = subprocess.check_output(['cygpath', '-w', dll_path]).strip()
+		# ldd on msys gives Unix-style paths, but mingw Python wants them Windows-style
+		# Use cygpath to convert the paths, because both mingw and msys Python can handle them
+		dll_path = subprocess.check_output(['cygpath', '-w', dll_path]).strip()
 		if dll_path.lower().startswith('c:\\windows'):
 			print('Skipping system DLL %s' % dll_path)
 			continue

--- a/get_deps.py
+++ b/get_deps.py
@@ -45,7 +45,8 @@ def main():
 		try:
 			shutil.copyfile(dll_path, os.path.join(args.dest, dll_name))
 		except shutil.Error as err:
-			# copyfile produces an exception if the files are the same
+			# This exception only gets raised if both files are exactly the same, but
+			# that doesn't matter to us
 			print('Copying failed: %s' % err)
 
 if __name__ == '__main__':

--- a/get_deps.py
+++ b/get_deps.py
@@ -33,7 +33,10 @@ def main():
 		if dll_path.lower().startswith('/c/windows') or dll_path.lower().startswith('c:/windows'):
 			print('Skipping system DLL %s' % dll_path)
 			continue
+
 		print('Copying %s...' % dll_path)
+		# Python wants Windows-style paths, not Unix-style
+		dll_path = subprocess.check_output(['cygpath', '-w', dll_path]).strip()
 		shutil.copyfile(dll_path, os.path.join(args.dest, dll_name))
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes the Python script copying the DLLs by converting the Unix path to Windows paths. Apparently Python recognizes that it's running on Windows and thus interprets the paths wrong.
I was building on Drive D, and Python interpreted the path "/mingw64/bin/libgcc_s_seh-1.dll" as "D:/mingw64/bin/libgcc_s_seh-1.dll", which was wrong in my case.
This fixes #62.