### PR TITLE
ui: Stop appending "-dirty" to clean AppVeyor builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ qemu-version.h: FORCE
 		else \
 			if test -d .git; then \
 				pkgvers=$$(git rev-parse --short HEAD 2>/dev/null | tr -d '\n');\
-				if ! git diff-index --quiet HEAD &>/dev/null; then \
+				if ! git diff --quiet HEAD >/dev/null 2>&1; then \
 					pkgvers="$${pkgvers}-dirty"; \
 				fi; \
 			fi; \


### PR DESCRIPTION
Closes #93 .

This is a fix for the Makefile bug which led to AppVeyor builds showing the revision as dirty.

Reasoning for switching from `git diff-index` to `git diff` stems from how these two operate.
On a fresh cloned repo `git diff-index` has no local index to look at, it just sees fresh files and reports them as new. `git diff` on the other hand actually looks at the files and the upstream tree, finding that the files are unmodified copies downloaded from the repo. It reports no changes and updates the local index.

This updating behaviour leads to `git diff-index` being able to correctly identify unchanged files - this led to my first proposed solution of running `git diff` before running the "dirty-check".