### PR TITLE
build.sh: use as many threads as CPUs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,7 @@ set -x # Print commands from now on
 	--disable-spice \
 	--disable-user \
 
-time make -j4 2>&1 | tee build.log
+time make -j`nproc` 2>&1 | tee build.log
 
 $POST_BUILD # call post build functions
 


### PR DESCRIPTION
This is a very trivial change I've been meaning to perform for a while; this shouldn't have many significant drawbacks.

I'm doing this from the web interface, so you'll obviously need to wait for the CI, but it should be pretty harmless.

It performs a clean build in 18 seconds on my Ryzen 2700X, IIRC.

The commit message may lack a few words (as there are CPUs?), but I am a bit tired right now, and this seems understandable to me :smile: 