### PR TITLE
Update configure with --disable-stack-protector

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ set -x # Print commands from now on
 	--enable-debug \
 	--extra-cflags="$CFLAGS_COMMON $CFLAGS" \
 	$CONFIGURE \
-    --target-list=i386-softmmu \
+	--target-list=i386-softmmu \
 	--enable-sdl \
 	--with-sdlabi=2.0 \
 	--disable-curl \
@@ -60,6 +60,7 @@ set -x # Print commands from now on
 	--disable-libiscsi \
 	--disable-spice \
 	--disable-user \
+	--disable-stack-protector \
 
 time make -j`nproc` 2>&1 | tee build.log
 


### PR DESCRIPTION
As noted in #106 this will produce working builds with GCC versions over 7.3.0-2. Upstream has already done this work-a-round.