### PR TITLE
Replace ffs() calls with ctz32()

### DIFF
--- a/hw/xbox/mcpx_apu.c
+++ b/hw/xbox/mcpx_apu.c
@@ -121,12 +121,12 @@ static const struct {
 
 #define MCPX_HW_MAX_VOICES 256
 
-#define GET_MASK(v, mask) (((v) & (mask)) >> (ffs(mask) - 1))
+#define GET_MASK(v, mask) (((v) & (mask)) >> ctz32(mask))
 
 #define SET_MASK(v, mask, val)                                       \
     do {                                                             \
         (v) &= ~(mask);                                              \
-        (v) |= ((val) << (ffs(mask) - 1)) & (mask);                  \
+        (v) |= ((val) << ctz32(mask)) & (mask);                      \
     } while (0)
 
 // #define MCPX_DEBUG
@@ -181,7 +181,7 @@ static uint32_t voice_get_mask(MCPXAPUState *d,
     hwaddr voice = d->regs[NV_PAPU_VPVADDR]
                     + voice_handle * NV_PAVS_SIZE;
     return (ldl_le_phys(&address_space_memory, voice + offset) & mask)
-              >> (ffs(mask) - 1);
+              >> ctz32(mask);
 }
 static void voice_set_mask(MCPXAPUState *d,
                            unsigned int voice_handle,
@@ -194,7 +194,7 @@ static void voice_set_mask(MCPXAPUState *d,
                     + voice_handle * NV_PAVS_SIZE;
     uint32_t v = ldl_le_phys(&address_space_memory, voice + offset) & ~mask;
     stl_le_phys(&address_space_memory, voice + offset,
-                v | ((val << (ffs(mask) - 1)) & mask));
+                v | ((val << ctz32(mask)) & mask));
 }
 
 static void update_irq(MCPXAPUState *d)

--- a/hw/xbox/nv2a/nv2a.c
+++ b/hw/xbox/nv2a/nv2a.c
@@ -41,26 +41,6 @@
 #include "hw/xbox/nv2a/nv2a.h"
 
 
-#ifdef __WINNT__
-// HACK: mingw-w64 doesn't provide ffs, for now we just shove it here
-// TODO: decide on a better location
-int ffs(register int valu)
-{
-    register int bit;
-
-    if (valu == 0) {
-        return 0;
-    }
-
-    for (bit = 1; !(valu & 1); bit++) {
-        valu >>= 1;
-    }
-
-    return bit;
-}
-#endif
-
-
 #define DEFINE_PROTO(n)                                              \
     uint64_t n##_read(void *opaque, hwaddr addr, unsigned int size); \
     void n##_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size);

--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -38,14 +38,14 @@
 #include "hw/xbox/nv2a/nv2a_debug.h"
 #include "hw/xbox/nv2a/nv2a_regs.h"
 
-#define GET_MASK(v, mask) (((v) & (mask)) >> (ffs(mask) - 1))
+#define GET_MASK(v, mask) (((v) & (mask)) >> ctz32(mask))
 
 #define SET_MASK(v, mask, val)                            \
     ({                                                    \
         const unsigned int __val = (val);                 \
         const unsigned int __mask = (mask);               \
         (v) &= ~(__mask);                                 \
-        (v) |= ((__val) << (ffs(__mask) - 1)) & (__mask); \
+        (v) |= ((__val) << ctz32(__mask)) & (__mask);     \
     })
 
 #define CASE_4(v, step)      \

--- a/hw/xbox/nv2a/nv2a_pfifo.c
+++ b/hw/xbox/nv2a/nv2a_pfifo.c
@@ -459,7 +459,7 @@ static uint32_t ramht_hash(NV2AState *d, uint32_t handle)
         1 << (GET_MASK(d->pfifo.regs[NV_PFIFO_RAMHT], NV_PFIFO_RAMHT_SIZE)+12);
 
     /* XXX: Think this is different to what nouveau calculates... */
-    unsigned int bits = ffs(ramht_size)-2;
+    unsigned int bits = ctz32(ramht_size)-1;
 
     uint32_t hash = 0;
     while (handle) {


### PR DESCRIPTION
This replaces all ffs() calls in NV2A and MCPX with calls to ctz32() and adjusts the surrounding code. It also removes the ffs() implementation in NV2A provided for Windows.
The changes build and run fine under Arch Linux and Windows 7 (as far as I can tell).

Resolves #88.