### PR TITLE
Fix EEPROM writeback; implement writing EEPROM to file

### DIFF
--- a/hw/i2c/smbus_eeprom.c
+++ b/hw/i2c/smbus_eeprom.c
@@ -26,6 +26,7 @@
 #include "hw/hw.h"
 #include "hw/i2c/i2c.h"
 #include "hw/i2c/smbus.h"
+#include "hw/xbox/xbox.h"
 
 //#define DEBUG
 
@@ -84,6 +85,8 @@ static void eeprom_write_data(SMBusDevice *dev, uint8_t cmd, uint8_t *buf, int l
     len -= n;
     if (len)
         memcpy(eeprom->data, buf + n, len);
+
+    save_eeprom(eeprom->data);
 }
 
 static uint8_t eeprom_read_data(SMBusDevice *dev, uint8_t cmd, int n)

--- a/hw/xbox/amd_smbus.c
+++ b/hw/xbox/amd_smbus.c
@@ -112,7 +112,7 @@ static void amd756_smb_transaction(AMD756SMBus *s)
             s->smb_data0 = val;
             s->smb_data1 = val >> 8;
         } else {
-            smbus_write_word(bus, addr, cmd, s->smb_data0);
+            smbus_write_word(bus, addr, cmd, (s->smb_data1 << 8) | s->smb_data0);
         }
         break;
     case AMD756_BLOCK_DATA:

--- a/hw/xbox/xbox.h
+++ b/hw/xbox/xbox.h
@@ -22,10 +22,12 @@
 #define HW_XBOX_H
 
 #include "hw/boards.h"
+#include "include/hw/i386/pc.h"
 
 #define MAX_IDE_BUS 2
 
 uint8_t *load_eeprom(void);
+void save_eeprom(uint8_t *eepromBuffer);
 
 void xbox_init_common(MachineState *machine,
                       const uint8_t *eeprom,


### PR DESCRIPTION
Fixes a bug while writing to the eeprom (writing 0xABCD) would write (0xAB00) 
https://github.com/0DaveX/xqemu/blob/9344483a0ce7079c874f7e0db9ea38e1bc576ba9/hw/xbox/amd_smbus.c#L115
https://github.com/0DaveX/xqemu/blob/84e63a64a42197f01785c6df93a4f48e6448f0b2/hw/xbox/amd_smbus.c#L115

also followup to @dracc his EEPROM PR 
> Ideally we'd store the EEPROM contents in a file which is read and written at runtime.

so it fixes #107 