### PR TITLE
Pixel shader cleanup

### DIFF
--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -2751,7 +2751,7 @@ static void pgraph_shader_update_constants(PGRAPHState *pg,
     int i, j;
 
     /* update combiner constants */
-    for (i = 0; i<= 8; i++) {
+    for (i = 0; i < 9; i++) {
         uint32_t constant[2];
         if (i == 8) {
             /* final combiner */

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -245,9 +245,8 @@ static QString* get_var(struct PixelShader *ps, int reg, bool is_dest)
         }
         break;
     case PS_REGISTER_C0:
-        /* TODO: should the final stage really always be unique? */
         if (ps->flags & PS_COMBINERCOUNT_UNIQUE_C0 || ps->cur_stage == 8) {
-            QString *reg = qstring_from_fmt("c_%d_%d", ps->cur_stage, 0);
+            QString *reg = qstring_from_fmt("c0_%d", ps->cur_stage);
             add_const_ref(ps, qstring_get_str(reg));
             if (ps->cur_stage == 8) {
                 ps->final_input.c0_used = true;
@@ -256,14 +255,14 @@ static QString* get_var(struct PixelShader *ps, int reg, bool is_dest)
             }
             return reg;
         } else {  // Same c0
-            add_const_ref(ps, "c_0_0");
+            add_const_ref(ps, "c0_0");
             ps->stage[0].c0_used = true;
-            return qstring_from_str("c_0_0");
+            return qstring_from_str("c0_0");
         }
         break;
     case PS_REGISTER_C1:
         if (ps->flags & PS_COMBINERCOUNT_UNIQUE_C1 || ps->cur_stage == 8) {
-            QString *reg = qstring_from_fmt("c_%d_%d", ps->cur_stage, 1);
+            QString *reg = qstring_from_fmt("c1_%d", ps->cur_stage);
             add_const_ref(ps, qstring_get_str(reg));
             if (ps->cur_stage == 8) {
                 ps->final_input.c1_used = true;
@@ -272,9 +271,9 @@ static QString* get_var(struct PixelShader *ps, int reg, bool is_dest)
             }
             return reg;
         } else {  // Same c1
-            add_const_ref(ps, "c_0_1");
+            add_const_ref(ps, "c1_0");
             ps->stage[0].c1_used = true;
-            return qstring_from_str("c_0_1");
+            return qstring_from_str("c1_0");
         }
         break;
     case PS_REGISTER_FOG:

--- a/hw/xbox/nv2a/nv2a_shaders.c
+++ b/hw/xbox/nv2a/nv2a_shaders.c
@@ -934,9 +934,9 @@ ShaderBinding* generate_shaders(const ShaderState state)
     ret->gl_primitive_mode = gl_primitive_mode;
 
     /* lookup fragment shader uniforms */
-    for (i=0; i<=8; i++) {
-        for (j=0; j<2; j++) {
-            snprintf(tmp, sizeof(tmp), "c_%d_%d", i, j);
+    for (i = 0; i < 9; i++) {
+        for (j = 0; j < 2; j++) {
+            snprintf(tmp, sizeof(tmp), "c%d_%d", j, i);
             ret->psh_constant_loc[i][j] = glGetUniformLocation(program, tmp);
         }
     }


### PR DESCRIPTION
*I've originally intended to do more changes as part of a larger PR, but am splitting it into managable chunks now. This code has not been tested but it should work. Please test and review.*

This PR makes our c0 / c1 names more logical, and removes some dead-code. We had some variables which were only written, but never read.
I've also re-ordered texture/const-declaration and alpha-ref-logic code, because our order didn't make sense.

There should be no changes in observed behaviour.