### PR TITLE
Force GL surface transfer on surface address or pitch changes

### DIFF
--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -738,16 +738,21 @@ static void pgraph_method(NV2AState *d,
             GET_MASK(parameter, NV097_SET_SURFACE_PITCH_COLOR);
         pg->surface_zeta.pitch =
             GET_MASK(parameter, NV097_SET_SURFACE_PITCH_ZETA);
+
+        pg->surface_color.buffer_dirty = true;
+        pg->surface_zeta.buffer_dirty = true;
         break;
     case NV097_SET_SURFACE_COLOR_OFFSET:
         pgraph_update_surface(d, false, true, true);
 
         pg->surface_color.offset = parameter;
+        pg->surface_color.buffer_dirty = true;
         break;
     case NV097_SET_SURFACE_ZETA_OFFSET:
         pgraph_update_surface(d, false, true, true);
 
         pg->surface_zeta.offset = parameter;
+        pg->surface_zeta.buffer_dirty = true;
         break;
 
     case NV097_SET_COMBINER_ALPHA_ICW ...

--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -3379,11 +3379,9 @@ static void pgraph_update_surface_part(NV2AState *d, bool upload, bool color) {
         }
         surface->buffer_dirty = false;
 
-#ifdef DEBUG_NV2A
-        uint8_t *out = data + surface->offset + 64;
-        NV2A_DPRINTF("upload_surface %s 0x%" HWADDR_PRIx " - 0x%" HWADDR_PRIx ", "
+        NV2A_GL_DPRINTF(true, "upload_surface %s 0x%" HWADDR_PRIx " - 0x%" HWADDR_PRIx ", "
                       "(0x%" HWADDR_PRIx " - 0x%" HWADDR_PRIx ", "
-                        "%d %d, %d %d, %d) - %x %x %x %x\n",
+                        "%d %d, %d %d, %d)",
             color ? "color" : "zeta",
             dma.address, dma.address + dma.limit,
             dma.address + surface->offset,
@@ -3391,9 +3389,7 @@ static void pgraph_update_surface_part(NV2AState *d, bool upload, bool color) {
             pg->surface_shape.clip_x, pg->surface_shape.clip_y,
             pg->surface_shape.clip_width,
             pg->surface_shape.clip_height,
-            surface->pitch,
-            out[0], out[1], out[2], out[3]);
-#endif
+            surface->pitch);
     }
 
     if (!upload && surface->draw_dirty) {
@@ -3425,20 +3421,16 @@ static void pgraph_update_surface_part(NV2AState *d, bool upload, bool color) {
         surface->draw_dirty = false;
         surface->write_enabled_cache = false;
 
-#ifdef DEBUG_NV2A
-        uint8_t *out = data + surface->offset + 64;
-        NV2A_DPRINTF("read_surface %s 0x%" HWADDR_PRIx " - 0x%" HWADDR_PRIx ", "
+        NV2A_GL_DPRINTF(true, "read_surface %s 0x%" HWADDR_PRIx " - 0x%" HWADDR_PRIx ", "
                       "(0x%" HWADDR_PRIx " - 0x%" HWADDR_PRIx ", "
-                        "%d %d, %d %d, %d) - %x %x %x %x\n",
+                        "%d %d, %d %d, %d)",
             color ? "color" : "zeta",
             dma.address, dma.address + dma.limit,
             dma.address + surface->offset,
             dma.address + surface->pitch * pg->surface_shape.clip_height,
             pg->surface_shape.clip_x, pg->surface_shape.clip_y,
             pg->surface_shape.clip_width, pg->surface_shape.clip_height,
-            surface->pitch,
-            out[0], out[1], out[2], out[3]);
-#endif
+            surface->pitch);
     }
 
     if (swizzle) {


### PR DESCRIPTION
Our surface logic is really flawed.

In "Tony Hawk's American Wasteland" the game has data in buffer A [640x480], then it switches to buffer B [320x240], then buffer C [640x480], and then back to buffer A [640x480].

Our current code downloads (GL to RAM) the surface when going from A -> B (so A is up-to-date), it's not uploaded (RAM to GL) again when going from C -> A. So the GL buffer for A remains what was in the GL buffer for C. If we switch to another buffer now, A might be downloaded to RAM again, and will have completly wrong contents (GL buffer contents of C!).

That is because our current code only appears to check if the CPU has written a surface OR if the surface shape has changed before re-uploading. It doesn't even care if the address changed. The same issue exists for surface pitch.

This PR changes the debug code so this can be observed in apitrace, and then it addresses the problem, by manually marking the surface as dirty when the address or pitch are touched.
This fixes the described issue in "Tony Hawk's American Wasteland" (and probably other games using bloom or other similar screen-space effects).

I'm not sure if my solution is good, because I haven't worked with our rather complicated surface logic in a while.

This change can be very bad for performance, as a lot more transfers are possibly forced. It should eventually be implemented closer to what we do for `surface_shape` already (only force an update, if the actual value changed). However, someone else can fix it later.

*There might be other cases where we run into similar issues, there'll be a separate issue about this*