### PR TITLE
nv2a: re-enable texture caching

### DIFF
--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -38,6 +38,8 @@
 #include "hw/xbox/nv2a/nv2a_debug.h"
 #include "hw/xbox/nv2a/nv2a_regs.h"
 
+#define USE_TEXTURE_CACHE 1
+
 #define GET_MASK(v, mask) (((v) & (mask)) >> ctz32(mask))
 
 #define SET_MASK(v, mask, val)                            \


### PR DESCRIPTION
Texture caching (enabled via USE_TEXTURE_CACHE macro) got turned off in
a cleanup commit (3d33d81). Turn it back on for performance.