### PR TITLE
rtc: Turn off debug messages

### DIFF
--- a/hw/timer/mc146818rtc.c
+++ b/hw/timer/mc146818rtc.c
@@ -39,7 +39,7 @@
 #include "hw/i386/apic.h"
 #endif
 
-#define DEBUG_CMOS
+//#define DEBUG_CMOS
 //#define DEBUG_COALESCED
 
 #ifdef DEBUG_CMOS


### PR DESCRIPTION
Debug messages got turned on when porting over XBOX RTC changes. It's
quite noisy during startup, so keep them turned off by default.