### PR TITLE
nv2a: Fix window-clip region off-by-one error

### DIFF
--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -3138,24 +3138,24 @@ static void pgraph_bind_shaders(PGRAPHState *pg)
         }
 
         uint32_t x   = pg->regs[NV_PGRAPH_WINDOWCLIPX0 + i * 4];
-        GLuint x_min = GET_MASK(x, NV_PGRAPH_WINDOWCLIPX0_XMIN);
-        GLuint x_max = GET_MASK(x, NV_PGRAPH_WINDOWCLIPX0_XMAX);
+        unsigned int x_min = GET_MASK(x, NV_PGRAPH_WINDOWCLIPX0_XMIN);
+        unsigned int x_max = GET_MASK(x, NV_PGRAPH_WINDOWCLIPX0_XMAX);
 
         /* Adjust y-coordinates for the OpenGL viewport: translate coordinates
          * to have the origin at the bottom-left of the surface (as opposed to
          * top-left), and flip y-min and y-max accordingly.
          */
         uint32_t y   = pg->regs[NV_PGRAPH_WINDOWCLIPY0 + i * 4];
-        GLuint y_min = (pg->surface_shape.clip_height - 1) -
-                       GET_MASK(y, NV_PGRAPH_WINDOWCLIPY0_YMAX);
-        GLuint y_max = (pg->surface_shape.clip_height - 1) -
-                       GET_MASK(y, NV_PGRAPH_WINDOWCLIPY0_YMIN);
+        unsigned int y_min = (pg->surface_shape.clip_height - 1) -
+                             GET_MASK(y, NV_PGRAPH_WINDOWCLIPY0_YMAX);
+        unsigned int y_max = (pg->surface_shape.clip_height - 1) -
+                             GET_MASK(y, NV_PGRAPH_WINDOWCLIPY0_YMIN);
 
         pgraph_apply_anti_aliasing_factor(pg, &x_min, &y_min);
         pgraph_apply_anti_aliasing_factor(pg, &x_max, &y_max);
 
         glUniform4i(pg->shader_binding->clip_region_loc[i],
-                    x_min, y_min, x_max, y_max);
+                    x_min, y_min, x_max + 1, y_max + 1);
     }
 
     pgraph_shader_update_constants(pg, pg->shader_binding, binding_changed,


### PR DESCRIPTION
Fixes an off-by-one error in the window-clipping.

The lower right corner should be inclusive. So `x1 = x0 + 10` has to lead to a 11 pixel wide region (same deal with vertical size).

I did *not* test the exclusive mode, overlapping regions, anti-aliasing, surface clipping which might lead to overflows / underflows, and similar scenarios. This really *only* fixes an off-by-one.

The only other minor change I did was to change the type of involved variables to `unsigned int` because `pgraph_apply_anti_aliasing_factor` operates on `unsigned int*`, so using `GLuint` felt unsafe.

---

I tested this against a modified nxdk triangle sample, which contained the following code:

```c
/* Set up window-clipping region */
p = pb_begin();
pb_push1(p, NV097_SET_WINDOW_CLIP_TYPE, 0); p+=2;
for(i = 0; i < 8; i++) {
  int x0 = 5+i*20;
  int y0 = 5;
  int x1 = x0+10;
  int y1 = y0+10;
  pb_push1(p, NV097_SET_WINDOW_CLIP_HORIZONTAL + i * 4, (x1 << 16) | x0); p+=2;
  pb_push1(p, NV097_SET_WINDOW_CLIP_VERTICAL + i * 4, (y1 << 16) | y0); p+=2;          
}
pb_end(p);
```

(I have also modified the background color so the clip region was more visible)

Tracing on Xbox was done with a modified version of nv2a-trace (needed fixes for nxdk dumping), tracing for XQEMU was done using apitrace.

XQEMU behaviour after this patch, matches the behaviour of real hardware, for the tested configuration.

---

**Unit-test (relevant top-left corner only; all images cropped identically):**

[XQEMU before patch](https://user-images.githubusercontent.com/360330/48060998-e1e8d080-e1bd-11e8-9d2e-c2c3cf2a9f26.png), [XQEMU after patch](https://user-images.githubusercontent.com/360330/48060996-e1e8d080-e1bd-11e8-8fc2-1a92a0ec0c1f.png), [Xbox](https://user-images.githubusercontent.com/360330/48060997-e1e8d080-e1bd-11e8-823d-159150cf1c2e.png)


**Prince of Persia with this patch (Compare #123):**

![Prince of Persia (fixed)](https://user-images.githubusercontent.com/360330/48061255-a0a4f080-e1be-11e8-9743-4b31913a9af7.png)

---

This closes #123.

Please re-test #124 and possibly other games which had similar issues.