### PR TITLE
ui: Set SDL2 'busy' interval to 16ms

### DIFF
--- a/ui/sdl2.c
+++ b/ui/sdl2.c
@@ -49,7 +49,7 @@ static int guest_x, guest_y;
 static SDL_Cursor *guest_sprite;
 static Notifier mouse_mode_notifier;
 
-#define SDL2_REFRESH_INTERVAL_BUSY 10
+#define SDL2_REFRESH_INTERVAL_BUSY 16
 #define SDL2_MAX_IDLE_COUNT (2 * GUI_REFRESH_INTERVAL_DEFAULT \
                              / SDL2_REFRESH_INTERVAL_BUSY + 1)
 


### PR DESCRIPTION
This is the refresh interval used when the user is actively providing
input (moving the mouse around) vs idle. Since this refresh event is
used to create vsync, this can cause some games which use vsync for
timekeeping to advance faster when moving the mouse around or using the
keyboard. For example, in the Halo:CE main menu, when moving the mouse
around the background animation will run a little faster.