### PR TITLE
Add release builds to appveyor

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -35,4 +35,10 @@ set CHERE_INVOKING=yes
 rem Build/test scripting
 bash -xlc "set pwd"
 bash -xlc "env"
-bash -xlc "./build.sh"
+
+IF "%1%" == "Release" (
+    bash -xlc "./build.sh --release"
+) ELSE (
+    bash -xlc "./build.sh"
+)
+

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -19,6 +19,9 @@ rem Install the relevant native dependencies
 bash -xlc "pacman --noconfirm -S --needed git"
 bash -xlc "pacman --noconfirm -S --needed openssl"
 bash -xlc "pacman --noconfirm -S --needed python2"
+rem --------
+bash -xlc "python -v -c 'import ssl; print ssl.OPENSSL_VERSION; import hashlib'"
+rem --------
 bash -xlc "pacman --noconfirm -S --needed make"
 bash -xlc "pacman --noconfirm -S --needed autoconf"
 bash -xlc "pacman --noconfirm -S --needed automake-wrapper"

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -19,6 +19,11 @@ rem Install the relevant native dependencies
 bash -xlc "pacman --noconfirm -S --needed git"
 bash -xlc "pacman --noconfirm -S --needed openssl"
 bash -xlc "pacman --noconfirm -S --needed python2"
+
+bash -xlc "ldd /usr/bin/python2.7.exe; python -v -c 'import ssl; print ssl.OPENSSL_VERSION; import hashlib;'"
+
+exit 1
+
 bash -xlc "pacman --noconfirm -S --needed make"
 bash -xlc "pacman --noconfirm -S --needed autoconf"
 bash -xlc "pacman --noconfirm -S --needed automake-wrapper"

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -20,7 +20,9 @@ bash -xlc "pacman --noconfirm -S --needed git"
 bash -xlc "pacman --noconfirm -S --needed openssl"
 bash -xlc "pacman --noconfirm -S --needed python2"
 
-bash -xlc "ldd /usr/bin/python2.7.exe; python -v -c 'import ssl; print ssl.OPENSSL_VERSION; import hashlib;'"
+bash -xlc "env"
+bash -xlc "ldd python; python -v -c 'import ssl; print ssl.OPENSSL_VERSION; import hashlib;'"
+bash -xlc "ldd /usr/bin/python2.7.exe; /usr/bin/python2.7 -v -c 'import ssl; print ssl.OPENSSL_VERSION; import hashlib;'"
 
 exit 1
 

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -17,15 +17,6 @@ bash -xlc "pacman --noconfirm -S --needed base-devel"
 
 rem Install the relevant native dependencies
 bash -xlc "pacman --noconfirm -S --needed git"
-bash -xlc "pacman --noconfirm -S --needed openssl"
-bash -xlc "pacman --noconfirm -S --needed python2"
-
-bash -xlc "env"
-bash -xlc "ldd python; python -v -c 'import ssl; print ssl.OPENSSL_VERSION; import hashlib;'"
-bash -xlc "ldd /usr/bin/python2.7.exe; /usr/bin/python2.7 -v -c 'import ssl; print ssl.OPENSSL_VERSION; import hashlib;'"
-
-exit 1
-
 bash -xlc "pacman --noconfirm -S --needed make"
 bash -xlc "pacman --noconfirm -S --needed autoconf"
 bash -xlc "pacman --noconfirm -S --needed automake-wrapper"
@@ -45,8 +36,8 @@ bash -xlc "set pwd"
 bash -xlc "env"
 
 IF "%1%" == "Release" (
-    bash -xlc "./build.sh --release --python=/usr/bin/python2.exe"
+    bash -xlc "./build.sh --release"
 ) ELSE (
-    bash -xlc "./build.sh --python=/usr/bin/python2.exe"
+    bash -xlc "./build.sh"
 )
 

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -17,6 +17,7 @@ bash -xlc "pacman --noconfirm -S --needed base-devel"
 
 rem Install the relevant native dependencies
 bash -xlc "pacman --noconfirm -S --needed git"
+bash -xlc "pacman --noconfirm -S --needed openssl"
 bash -xlc "pacman --noconfirm -S --needed python2"
 bash -xlc "pacman --noconfirm -S --needed make"
 bash -xlc "pacman --noconfirm -S --needed autoconf"

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -19,9 +19,6 @@ rem Install the relevant native dependencies
 bash -xlc "pacman --noconfirm -S --needed git"
 bash -xlc "pacman --noconfirm -S --needed openssl"
 bash -xlc "pacman --noconfirm -S --needed python2"
-rem --------
-bash -xlc "python -v -c 'import ssl; print ssl.OPENSSL_VERSION; import hashlib'"
-rem --------
 bash -xlc "pacman --noconfirm -S --needed make"
 bash -xlc "pacman --noconfirm -S --needed autoconf"
 bash -xlc "pacman --noconfirm -S --needed automake-wrapper"
@@ -41,8 +38,8 @@ bash -xlc "set pwd"
 bash -xlc "env"
 
 IF "%1%" == "Release" (
-    bash -xlc "./build.sh --release"
+    bash -xlc "./build.sh --release --python=/usr/bin/python2.exe"
 ) ELSE (
-    bash -xlc "./build.sh"
+    bash -xlc "./build.sh --python=/usr/bin/python2.exe"
 )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,13 @@ environment:
   matrix:
     - MSYS2_ARCH: x86_64
       MSYSTEM: MINGW64
-    # - MSYS2_ARCH: i686
-    #   MSYSTEM: MINGW32
+
+configuration:
+  - Release
+  - Debug
 
 build_script:
-  - '%APPVEYOR_BUILD_FOLDER%\appveyor.bat'
+  - '%APPVEYOR_BUILD_FOLDER%\appveyor.bat %CONFIGURATION%'
 
 deploy: off
 


### PR DESCRIPTION
This commit will enable appveyor to build both debug & release builds.

### Do not merge.
Builds are failing due to Python being updated in between `xqemu:master` and this commit. I've successfully built these changes on `gxtx:test` by disabling checking for Python updates in `appveyor.bat`.

Python was updated from `python2-2.7.15-2-x86_64` to `python2-2.7.15-3-x86_64`.