### PR TITLE
 dsp: Support 'inc d'  and 'dec d'

### DIFF
--- a/hw/xbox/dsp/dsp_cpu.c
+++ b/hw/xbox/dsp/dsp_cpu.c
@@ -249,7 +249,7 @@ static const OpcodeEntry nonparallel_opcodes[] = {
     { "0000110000011010100sSSSD", "extractu S1, S2, D", NULL, NULL },
     { "0000110000011000100s000D", "extractu #CO, S2, D", NULL, NULL },
     { "000000000000000000000101", "ill", NULL, emu_illegal },
-    { "00000000000000000000100d", "inc D", NULL, NULL },
+    { "00000000000000000000100d", "inc D", NULL, emu_inc },
     { "00001100000110110qqqSSSD", "insert S1, S2, D", NULL, NULL },
     { "00001100000110010qqq000D", "insert #CO, S2, D", NULL, NULL },
     { "00001110CCCCaaaaaaaaaaaa", "jcc xxx", dis_jcc_imm, emu_jcc_imm },

--- a/hw/xbox/dsp/dsp_cpu.c
+++ b/hw/xbox/dsp/dsp_cpu.c
@@ -228,7 +228,7 @@ static const OpcodeEntry nonparallel_opcodes[] = {
     { "00001100000111111111gggd", "cmpu S1, S2", dis_cmpu, emu_cmpu },
     { "000000000000001000000000", "debug", NULL, NULL },
     { "00000000000000110000CCCC", "debugcc", NULL, NULL },
-    { "00000000000000000000101d", "dec D", NULL, NULL, /*dis_dec, emu_dec*/ },
+    { "00000000000000000000101d", "dec D", NULL /*dis_dec*/, emu_dec },
     { "000000011000000001JJd000", "div S, D", dis_div, emu_div },
     { "000000010010010s1sdkQQQQ", "dmac S1, S2, D", NULL, NULL },
     { "0000011001MMMRRR0S000000", "do [X or Y]:ea, expr", dis_do_ea, emu_do_ea, match_MMMRRR },

--- a/hw/xbox/dsp/dsp_emu.inl
+++ b/hw/xbox/dsp/dsp_emu.inl
@@ -6605,6 +6605,44 @@ static void emu_cmpu(dsp_core_t* dsp)
     dsp->registers[DSP_REG_SR] |= (dest[0]>>4) & 0x8;
 }
 
+static void emu_dec(dsp_core_t* dsp)
+{
+    uint32_t destreg, source[3], dest[3];
+    uint16_t newsr;
+
+    destreg = DSP_REG_A + (dsp->cur_inst & 1);
+    if (destreg == DSP_REG_A) {
+        dest[0] = dsp->registers[DSP_REG_A2];
+        dest[1] = dsp->registers[DSP_REG_A1];
+        dest[2] = dsp->registers[DSP_REG_A0];
+    } else {
+        dest[0] = dsp->registers[DSP_REG_B2];
+        dest[1] = dsp->registers[DSP_REG_B1];
+        dest[2] = dsp->registers[DSP_REG_B0];
+    }
+
+    source[2] = 1;
+    source[1] = 0;
+    source[0] = 0;
+
+    newsr = dsp_sub56(source, dest);
+
+    if (destreg == DSP_REG_A) {
+        dsp->registers[DSP_REG_A2] = dest[0];
+        dsp->registers[DSP_REG_A1] = dest[1];
+        dsp->registers[DSP_REG_A0] = dest[2];
+    } else {
+        dsp->registers[DSP_REG_B2] = dest[0];
+        dsp->registers[DSP_REG_B1] = dest[1];
+        dsp->registers[DSP_REG_B0] = dest[2];
+    }
+
+    emu_ccr_update_e_u_n_z(dsp, dest[0], dest[1], dest[2]);
+
+    dsp->registers[DSP_REG_SR] &= BITMASK(16)-((1<<DSP_SR_V)|(1<<DSP_SR_C));
+    dsp->registers[DSP_REG_SR] |= newsr;
+}
+
 static void emu_div(dsp_core_t* dsp)
 {
     uint32_t srcreg, destreg, source[3], dest[3];

--- a/hw/xbox/dsp/dsp_emu.inl
+++ b/hw/xbox/dsp/dsp_emu.inl
@@ -6808,6 +6808,44 @@ static void emu_illegal(dsp_core_t* dsp)
     }
 }
 
+static void emu_inc(dsp_core_t* dsp)
+{
+    uint32_t destreg, source[3], dest[3];
+    uint16_t newsr;
+
+    destreg = DSP_REG_A + (dsp->cur_inst & 1);
+    if (destreg == DSP_REG_A) {
+        dest[0] = dsp->registers[DSP_REG_A2];
+        dest[1] = dsp->registers[DSP_REG_A1];
+        dest[2] = dsp->registers[DSP_REG_A0];
+    } else {
+        dest[0] = dsp->registers[DSP_REG_B2];
+        dest[1] = dsp->registers[DSP_REG_B1];
+        dest[2] = dsp->registers[DSP_REG_B0];
+    }
+
+    source[2] = 1;
+    source[1] = 0;
+    source[0] = 0;
+
+    newsr = dsp_add56(source, dest);
+
+    if (destreg == DSP_REG_A) {
+        dsp->registers[DSP_REG_A2] = dest[0];
+        dsp->registers[DSP_REG_A1] = dest[1];
+        dsp->registers[DSP_REG_A0] = dest[2];
+    } else {
+        dsp->registers[DSP_REG_B2] = dest[0];
+        dsp->registers[DSP_REG_B1] = dest[1];
+        dsp->registers[DSP_REG_B0] = dest[2];
+    }
+
+    emu_ccr_update_e_u_n_z(dsp, dest[0], dest[1], dest[2]);
+
+    dsp->registers[DSP_REG_SR] &= BITMASK(16)-((1<<DSP_SR_V)|(1<<DSP_SR_C));
+    dsp->registers[DSP_REG_SR] |= newsr;
+}
+
 static void emu_jcc_imm(dsp_core_t* dsp)
 {
     uint32_t cc_code, newpc;


### PR DESCRIPTION
Saw 'inc d' in some games GP FX or EP AC3 code once, so we will probably need it for audio emulation; also using it in DSP homebrew now. Adding 'dec d' was more of an afterthought for completeness.

I tested my implementation using https://github.com/JayFoxRox/xbox-tools/pull/70 (requires https://github.com/XboxDev/a56/pull/9).
I ran a couple of test cases to see how flags behave and if A / B register selection works. Everything seems to work fine, except readback issues which are likely caused by #148 and #149.

I did not implement the respective disassemblers yet (and don't intend to do so).

I didn't check for correctness of SR.S and SR.L bits, simply because they don't seem to be updated explicitly by most of our DSP code. These will have to be fixed in the future, if they are broken.