### PR TITLE
Address minor APU bugs

### DIFF
--- a/hw/xbox/mcpx_apu.c
+++ b/hw/xbox/mcpx_apu.c
@@ -101,6 +101,7 @@ static const struct {
 #define NV1BA0_PIO_VOICE_ON                              0x00000124
 #   define NV1BA0_PIO_VOICE_ON_HANDLE                       0x0000FFFF
 #define NV1BA0_PIO_VOICE_OFF                             0x00000128
+#   define NV1BA0_PIO_VOICE_OFF_HANDLE                      0x0000FFFF
 #define NV1BA0_PIO_VOICE_PAUSE                           0x00000140
 #   define NV1BA0_PIO_VOICE_PAUSE_HANDLE                    0x0000FFFF
 #   define NV1BA0_PIO_VOICE_PAUSE_ACTION                    (1 << 18)
@@ -327,7 +328,7 @@ static void fe_method(MCPXAPUState *d,
         }
         break;
     case NV1BA0_PIO_VOICE_OFF:
-        voice_set_mask(d, argument,
+        voice_set_mask(d, argument & NV1BA0_PIO_VOICE_OFF_HANDLE,
                 NV_PAVS_VOICE_PAR_STATE,
                 NV_PAVS_VOICE_PAR_STATE_ACTIVE_VOICE,
                 0);

--- a/hw/xbox/mcpx_apu.c
+++ b/hw/xbox/mcpx_apu.c
@@ -320,12 +320,11 @@ static void fe_method(MCPXAPUState *d,
                 NV_PAVS_VOICE_TAR_PITCH_LINK,
                 NV_PAVS_VOICE_TAR_PITCH_LINK_NEXT_VOICE_HANDLE,
                 selected_handle);
-
-            voice_set_mask(d, selected_handle,
-                    NV_PAVS_VOICE_PAR_STATE,
-                    NV_PAVS_VOICE_PAR_STATE_ACTIVE_VOICE,
-                    1);
         }
+        voice_set_mask(d, selected_handle,
+                NV_PAVS_VOICE_PAR_STATE,
+                NV_PAVS_VOICE_PAR_STATE_ACTIVE_VOICE,
+                1);
         break;
     case NV1BA0_PIO_VOICE_OFF:
         voice_set_mask(d, argument & NV1BA0_PIO_VOICE_OFF_HANDLE,

--- a/hw/xbox/mcpx_apu.c
+++ b/hw/xbox/mcpx_apu.c
@@ -412,9 +412,9 @@ static void scratch_rw(hwaddr sge_base, unsigned int max_sge,
         unsigned int entry = (addr + i) / TARGET_PAGE_SIZE;
         assert(entry < max_sge);
         uint32_t prd_address = ldl_le_phys(&address_space_memory,
-                                           sge_base + entry * 8);
+                                           sge_base + entry * 8 + 0);
         /* uint32_t prd_control = ldl_le_phys(&address_space_memory,
-                                            sge_base + entry*4*2 + 1); */
+                                            sge_base + entry * 8 + 4); */
 
         hwaddr paddr = prd_address + (addr + i) % TARGET_PAGE_SIZE;
 


### PR DESCRIPTION
**Use NV1BA0_PIO_VOICE_OFF_HANDLE mask**:

Should help with understanding the code


**Fix offset of scratch space PRD control word**:

If this code ever gets used, this should be correct now


**Activate voice on VOICE_ON, regardless of list position**:

I assume this was a bug in the code; the voice should probably always go active on VOICE_ON.


---

All of these changes come from https://github.com/JayFoxRox/xqemu-espes/pull/24