### PR TITLE
apu: Access system memory directly

### DIFF
--- a/hw/xbox/mcpx_apu.h
+++ b/hw/xbox/mcpx_apu.h
@@ -1,0 +1,25 @@
+/*
+ * QEMU Geforce NV2A implementation
+ *
+ * Copyright (c) 2018 Jannik Vogel
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef HW_MCPX_APU_H
+#define HW_MCPX_APU_H
+
+void mcpx_apu_init(PCIBus *bus, int devfn, MemoryRegion *ram);
+
+#endif

--- a/hw/xbox/xbox.c
+++ b/hw/xbox/xbox.c
@@ -47,6 +47,7 @@
 #include "hw/xbox/xbox_pci.h"
 #include "hw/xbox/smbus.h"
 #include "hw/xbox/nv2a/nv2a.h"
+#include "hw/xbox/mcpx_apu.h"
  
 #include "hw/xbox/xbox.h"
 
@@ -405,7 +406,7 @@ void xbox_init_common(MachineState *machine,
     }
 
     /* APU! */
-    pci_create_simple(pci_bus, PCI_DEVFN(5, 0), "mcpx-apu");
+    mcpx_apu_init(pci_bus, PCI_DEVFN(5, 0), ram_memory);
 
     /* ACI! */
     pci_create_simple(pci_bus, PCI_DEVFN(6, 0), "mcpx-aci");


### PR DESCRIPTION
This improves the APU memory access performance. This will be more important when we implement better DMA (possibly more data to transfer), VP (audio buffers must be loaded) and EP (FIFO must be read and written back).

Closes #156.

*I did not check for self-modifying PRDs (I don't think this is likely to happen, until we write our own crazy DSP homebrew).*

---

This has gotten very little testing. Please review my new logic for `scratch_rw`.