### PR TITLE
Support FIFO output in DMA

### DIFF
--- a/hw/xbox/dsp/dsp.c
+++ b/hw/xbox/dsp/dsp.c
@@ -56,7 +56,9 @@ struct DSPState {
 static uint32_t read_peripheral(dsp_core_t* core, uint32_t address);
 static void write_peripheral(dsp_core_t* core, uint32_t address, uint32_t value);
 
-DSPState* dsp_init(void* scratch_rw_opaque, dsp_scratch_rw_func scratch_rw)
+DSPState *dsp_init(void *rw_opaque,
+                   dsp_scratch_rw_func scratch_rw,
+                   dsp_fifo_rw_func fifo_rw)
 {
     DPRINTF("dsp_init\n");
 
@@ -67,8 +69,9 @@ DSPState* dsp_init(void* scratch_rw_opaque, dsp_scratch_rw_func scratch_rw)
     dsp->core.write_peripheral = write_peripheral;
 
     dsp->dma.core = &dsp->core;
-    dsp->dma.scratch_rw_opaque = scratch_rw_opaque;
+    dsp->dma.rw_opaque = rw_opaque;
     dsp->dma.scratch_rw = scratch_rw;
+    dsp->dma.fifo_rw = fifo_rw;
 
     dsp_reset(dsp);
 
@@ -176,7 +179,7 @@ void dsp_run(DSPState* dsp, int cycles)
 void dsp_bootstrap(DSPState* dsp)
 {
     // scratch memory is dma'd in to pram by the bootrom
-    dsp->dma.scratch_rw(dsp->dma.scratch_rw_opaque,
+    dsp->dma.scratch_rw(dsp->dma.rw_opaque,
         (uint8_t*)dsp->core.pram, 0, 0x800*4, false);
 }
 

--- a/hw/xbox/dsp/dsp.h
+++ b/hw/xbox/dsp/dsp.h
@@ -32,10 +32,14 @@
 typedef struct DSPState DSPState;
 
 typedef void (*dsp_scratch_rw_func)(
-    void* opaque, uint8_t* ptr, uint32_t addr, size_t len, bool dir);
+    void *opaque, uint8_t *ptr, uint32_t addr, size_t len, bool dir);
+typedef void (*dsp_fifo_rw_func)(
+    void *opaque, uint8_t *ptr, unsigned int index, size_t len, bool dir);
 
 /* Dsp commands */
-DSPState* dsp_init(void* scratch_rw_opaque, dsp_scratch_rw_func scratch_rw);
+DSPState *dsp_init(void *rw_opaque,
+                   dsp_scratch_rw_func scratch_rw,
+                   dsp_fifo_rw_func fifo_rw);
 void dsp_destroy(DSPState* dsp);
 void dsp_reset(DSPState* dsp);
 

--- a/hw/xbox/dsp/dsp_dma.h
+++ b/hw/xbox/dsp/dsp_dma.h
@@ -36,8 +36,9 @@ typedef enum DSPDMARegister {
 typedef struct DSPDMAState {
     dsp_core_t* core;
 
-    void* scratch_rw_opaque;
+    void *rw_opaque;
     dsp_scratch_rw_func scratch_rw;
+    dsp_fifo_rw_func fifo_rw;
 
     uint32_t configuration;
     uint32_t control;

--- a/hw/xbox/mcpx_apu.c
+++ b/hw/xbox/mcpx_apu.c
@@ -419,7 +419,7 @@ static void scatter_gather_rw(MCPXAPUState *d,
     unsigned int bytes_to_copy = TARGET_PAGE_SIZE - offset_in_page;
 
     while (len > 0) {
-        assert(page_entry < max_sge);
+        assert(page_entry <= max_sge);
 
         uint32_t prd_address = ldl_le_phys(&address_space_memory,
                                            sge_base + page_entry * 8 + 0);

--- a/hw/xbox/mcpx_apu.c
+++ b/hw/xbox/mcpx_apu.c
@@ -873,8 +873,8 @@ static void mcpx_apu_realize(PCIDevice *dev, Error **errp)
 
 
     d->se.frame_timer = timer_new_ms(QEMU_CLOCK_VIRTUAL, se_frame, d);
-    d->gp.dsp = dsp_init(d, gp_scratch_rw);
-    d->ep.dsp = dsp_init(d, ep_scratch_rw);
+    d->gp.dsp = dsp_init(d, gp_scratch_rw, gp_fifo_rw);
+    d->ep.dsp = dsp_init(d, ep_scratch_rw, ep_fifo_rw);
 }
 
 static void mcpx_apu_class_init(ObjectClass *klass, void *data)


### PR DESCRIPTION
This adds support for FIFO output in APU DSP DMA transfers. This is used during the boot-animation to send the audio output to AC97.
During normal operation (post boot-animation), this DMA to AC97 is handled by the EP (which we currently don't emulate). So in practice, we don't need FIFOs at the moment.

However, this lays the groundwork for circular scatter gather. This is used for buffer type 0xE (scratch space with circular addressing). Buffer 0xE is used to send output from the GP to the EP. Buffer 0xE is broken in the master revision (and not handled by this PR), but we can easily fix this in a follow-up PR.

I based my code on [the findings I've documented in XboxDevWiki](http://xboxdevwiki.net/DSP#Command_blocks).
The code in this PR has been tested against real hardware, and was confirmed to work in various configurations.

I did not look too closely at input FIFOs yet, so it's possible that the code is broken.
I also didn't add the DMA handler for input FIFOs yet; it will happen in a follow-up PR (probably much later, when we need support).