### PR TITLE
nv2a: Fix NV097_SET_VERTEX_DATA2S scaling

### DIFF
--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -2169,15 +2169,10 @@ static void pgraph_method(NV2AState *d,
     case NV097_SET_VERTEX_DATA2S ...
             NV097_SET_VERTEX_DATA2S + 0x3c: {
         slot = (method - NV097_SET_VERTEX_DATA2S) / 4;
-        assert(false); /* FIXME: Untested! */
         VertexAttribute *attribute = &pg->vertex_attributes[slot];
         pgraph_allocate_inline_buffer_vertices(pg, slot);
-        /* FIXME: Is mapping to [-1,+1] correct? */
-        attribute->inline_value[0] = ((int16_t)(parameter & 0xFFFF) * 2.0 + 1)
-                                         / 65535.0;
-        attribute->inline_value[1] = ((int16_t)(parameter >> 16) * 2.0 + 1)
-                                         / 65535.0;
-        /* FIXME: Should these really be set to 0.0 and 1.0 ? Conditions? */
+        attribute->inline_value[0] = (float)(int16_t)(parameter & 0xFFFF);
+        attribute->inline_value[1] = (float)(int16_t)(parameter >> 16);
         attribute->inline_value[2] = 0.0;
         attribute->inline_value[3] = 1.0;
         if (slot == 0) {


### PR DESCRIPTION
Vertex attribute values provided via NV097_SET_VERTEX_DATA2S are
apparently two 16-bit signed integers, packed into 32 bits, which are
then to be directly mapped to floating point values in the range
[-32768.0, 32767.0].

Halo:CE uses this format to provide texture (u,v) coordinates for
render-to-texture techniques, including weapon scope, dynamic shadows,
and radar beacon--all of which are now working as expected with this
patch (*on branch [mborgerson:dev/halo](https://github.com/mborgerson/xqemu/tree/dev/halo), which allows for some additional 
unimplemented features which we will `assert` for on master branch*).

Fixes #165 
PartiallyFixes #119