### PR TITLE
docs: Use job-specific CI badges for macOS and Linux builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ and Linux. Please visit [xqemu.com](http://xqemu.com) to learn more.
 
 Build Status
 ------------
-| Windows | Linux | macOS |
+| Windows | macOS | Linux |
 | ------- | ----- | ----- |
-| [![Build status](https://ci.appveyor.com/api/projects/status/i1m0keigjabxg170/branch/master?svg=true)](https://ci.appveyor.com/project/xqemu-bot/xqemu) | [![Travis-CI Status](https://travis-ci.org/xqemu/xqemu.svg?branch=master)](https://travis-ci.org/xqemu/xqemu) | [![Travis-CI Status](https://travis-ci.org/xqemu/xqemu.svg?branch=master)](https://travis-ci.org/xqemu/xqemu) |
+| [![Build status](https://ci.appveyor.com/api/projects/status/i1m0keigjabxg170/branch/master?svg=true)](https://ci.appveyor.com/project/xqemu-bot/xqemu) | [![Travis-CI Status](https://travis-matrix-badges.herokuapp.com/repos/xqemu/xqemu/branches/master/2)](https://travis-ci.org/xqemu/xqemu) | [![Travis-CI Status](https://travis-matrix-badges.herokuapp.com/repos/xqemu/xqemu/branches/master/1)](https://travis-ci.org/xqemu/xqemu) |


### PR DESCRIPTION
As requested by JFR I've switched the place of the macOS and Linux CI badge titles.