### PR TITLE
build.sh: Use Python 3.x for Windows

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ package_windows() { # Script to prepare the windows exe
     mkdir -p dist
     cp i386-softmmu/qemu-system-i386.exe dist/xqemu.exe
     cp i386-softmmu/qemu-system-i386w.exe dist/xqemuw.exe
-    python2 ./get_deps.py dist/xqemu.exe dist
+    python3 ./get_deps.py dist/xqemu.exe dist
     strip dist/xqemu.exe
     strip dist/xqemuw.exe
 }
@@ -52,7 +52,7 @@ case "$(uname -s)" in # adjust compilation option based on platform
     CYGWIN*|MINGW*|MSYS*)
         echo 'Compiling for Windows…'
         sys_cflags='-Wno-error'
-        sys_opts='--python=python2 --disable-cocoa --disable-opengl'
+        sys_opts='--python=python3 --disable-cocoa --disable-opengl'
         postbuild='package_windows' # set the above function to be called after build
         ;;
     *)

--- a/get_deps.py
+++ b/get_deps.py
@@ -22,7 +22,7 @@ def main():
 	elif not os.path.isdir(args.dest):
 		print('File exists with destination name')
 		sys.exit(1)
-		
+
 	try:
 		subprocess.check_output(['cygpath', '--help'])
 	except OSError as err:
@@ -30,7 +30,7 @@ def main():
 		print("Make sure you're using a recent version of MSYS2 and that it works correctly.")
 		sys.exit(1)
 
-	sout = subprocess.check_output(['ldd', args.prog])
+	sout = subprocess.check_output(['ldd', args.prog]).decode('utf-8')
 	for line in sout.splitlines():
 		line = line.strip().split()
 		dll_name, dll_path, dll_load_addr = line[0], line[2], line[3]
@@ -39,7 +39,7 @@ def main():
 			continue
 		# ldd on msys gives Unix-style paths, but mingw Python wants them Windows-style
 		# Use cygpath to convert the paths, because both mingw and msys Python can handle them
-		dll_path = subprocess.check_output(['cygpath', '-w', dll_path]).strip()
+		dll_path = subprocess.check_output(['cygpath', '-w', dll_path]).decode('utf-8').strip()
 		if dll_path.lower().startswith('c:\\windows'):
 			print('Skipping system DLL %s' % dll_path)
 			continue


### PR DESCRIPTION
Python 2.x is turning EOL at the end of the year. All of the QEMU scripts are already 3.X compatible the only thing not compatible is our `get_deps.py` for copying Windows DLL for redistribution which is also fixed in this PR.

I've not done extensive testing but everything builds and runs fine.