### PR TITLE
apu: Add VP framework

### DIFF
--- a/hw/xbox/mcpx_apu.c
+++ b/hw/xbox/mcpx_apu.c
@@ -159,6 +159,8 @@ static const struct {
 #   define NV_PAVS_VOICE_TAR_PITCH_LINK_NEXT_VOICE_HANDLE   0x0000FFFF
 
 
+#define GP_DSP_MIXBUF_BASE 0x001400
+
 #define GP_OUTPUT_FIFO_COUNT  4
 #define GP_INPUT_FIFO_COUNT   2
 
@@ -659,7 +661,7 @@ static uint64_t gp_read(void *opaque,
     }
     case NV_PAPU_GPMIXBUF ... NV_PAPU_GPMIXBUF + 0x400 * 4 - 1: {
         uint32_t xaddr = (addr - NV_PAPU_GPMIXBUF) / 4;
-        r = dsp_read_memory(d->gp.dsp, 'X', 0x001400 + xaddr);
+        r = dsp_read_memory(d->gp.dsp, 'X', GP_DSP_MIXBUF_BASE + xaddr);
         break;
     }
     case NV_PAPU_GPYMEM ... NV_PAPU_GPYMEM + 0x800 * 4 - 1: {
@@ -698,7 +700,7 @@ static void gp_write(void *opaque, hwaddr addr,
     }
     case NV_PAPU_GPMIXBUF ... NV_PAPU_GPMIXBUF + 0x400 * 4 - 1: {
         uint32_t xaddr = (addr - NV_PAPU_GPMIXBUF) / 4;
-        dsp_write_memory(d->gp.dsp, 'X', 0x001400 + xaddr, val);
+        dsp_write_memory(d->gp.dsp, 'X', GP_DSP_MIXBUF_BASE + xaddr, val);
         break;
     }
     case NV_PAPU_GPYMEM ... NV_PAPU_GPYMEM + 0x800 * 4 - 1: {


### PR DESCRIPTION
This PR adds a small framework for implementing VP voice processing (which will happen in a future PR).
This framework includes VP &rarr; GP audio routing. Unfortunately this transfer is affected by #158 for 1024 words (32 channels * 32 samples).

For audio debugging purposes, this also adds a tone generator for injecting audio into the GP.
This tone isn't currently heard, because EP and ACI are severely broken (so audio isn't routed to speakers).
However, this tone will be useful in the future, to verify correct GP / EP behaviour, and can also be used to test audio-output without functional VP voice processing.