### PR TITLE
nv2a: Fix A8Y8 texture formats

### DIFF
--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -192,7 +192,7 @@ static const ColorFormatInfo kelvin_color_format_map[66] = {
          {GL_ONE, GL_ONE, GL_ONE, GL_RED}},
     [NV097_SET_TEXTURE_FORMAT_COLOR_SZ_A8Y8] =
         {2, false, GL_RG8, GL_RG, GL_UNSIGNED_BYTE,
-         {GL_GREEN, GL_GREEN, GL_GREEN, GL_RED}},
+         {GL_RED, GL_RED, GL_RED, GL_GREEN}},
     [NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_AY8] =
         {1, true, GL_R8, GL_RED, GL_UNSIGNED_BYTE,
          {GL_RED, GL_RED, GL_RED, GL_RED}},
@@ -207,7 +207,7 @@ static const ColorFormatInfo kelvin_color_format_map[66] = {
          {GL_ONE, GL_ONE, GL_ONE, GL_RED}},
     [NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_A8Y8] =
         {2, true, GL_RG8, GL_RG, GL_UNSIGNED_BYTE,
-         {GL_GREEN, GL_GREEN, GL_GREEN, GL_RED}},
+         {GL_RED, GL_RED, GL_RED, GL_GREEN}},
 
     [NV097_SET_TEXTURE_FORMAT_COLOR_SZ_R6G5B5] =
         {2, false, GL_RGB8_SNORM, GL_RGB, GL_BYTE}, /* FIXME: This might be signed */


### PR DESCRIPTION
Not confirmed on hardware (and I don't intend to do so), but based on very strong assumptions and observed behavior.

Please test with a couple of games to confirm I didn't break anything.

This closes #119 and closes #36 for Battle Creek and Cartographer. It also solves Halo issues with the HUD.

![Halo HUD and volumetric fog](https://user-images.githubusercontent.com/360330/52275668-7ba45300-2950-11e9-82e1-c6f5b583c9d2.png)

*(This branch was rebased onto https://github.com/mborgerson/xqemu/tree/dev/halo for the screenshot)*
