### PR TITLE
chihiro: Fix property names by avoiding illegal symbols

### DIFF
--- a/hw/xbox/chihiro.c
+++ b/hw/xbox/chihiro.c
@@ -321,9 +321,9 @@ static const uint8_t eeprom[] = {
 static void chihiro_init(MachineState *machine)
 {
     const char *mediaboard_rom_file = object_property_get_str(
-        qdev_get_machine(), "mediaboard_rom", NULL);
+        qdev_get_machine(), "mediaboard-rom", NULL);
     const char *mediaboard_filesystem_file = object_property_get_str(
-        qdev_get_machine(), "mediaboard_filesystem", NULL);
+        qdev_get_machine(), "mediaboard-filesystem", NULL);
     chihiro_ide_interface_init(mediaboard_rom_file,
                                mediaboard_filesystem_file);
 
@@ -388,16 +388,16 @@ static void machine_set_mediaboard_filesystem(Object *obj, const char *value,
 
 static inline void chihiro_machine_initfn(Object *obj)
 {
-    object_property_add_str(obj, "mediaboard_rom",
+    object_property_add_str(obj, "mediaboard-rom",
                             machine_get_mediaboard_rom,
                             machine_set_mediaboard_rom, NULL);
-    object_property_set_description(obj, "mediaboard_rom",
+    object_property_set_description(obj, "mediaboard-rom",
                                     "Chihiro mediaboard ROM", NULL);
 
-    object_property_add_str(obj, "mediaboard_filesystem",
+    object_property_add_str(obj, "mediaboard-filesystem",
                             machine_get_mediaboard_filesystem,
                             machine_set_mediaboard_filesystem, NULL);
-    object_property_set_description(obj, "mediaboard_filesystem",
+    object_property_set_description(obj, "mediaboard-filesystem",
                                     "Chihiro mediaboard filesystem", NULL);
 }
 


### PR DESCRIPTION
Trying to run chihiro currently fails with `qemu-system-i386: Property '.mediaboard-rom' not found
`

As @JayFoxRox pointed out that's due to underscores '_' being kind of not allowed.
(They are replaced by hyphens '-' )

https://github.com/xqemu/xqemu/blob/960698a24ed7cd69fe2e452a28a3bb64e395a0fe/vl.c#L2706-L2711