### PR TITLE
Final combiner G input is a scalar

### DIFF
--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -296,24 +296,30 @@ static QString* get_input_var(struct PixelShader *ps, struct InputInfo in, bool 
 {
     QString *reg = get_var(ps, in.reg, false);
 
-    switch (in.chan) {
-    case PS_CHANNEL_RGB:
-        if (is_alpha) {
-            qstring_append(reg, ".b");
-        } else {
+    if (!is_alpha) {
+        switch (in.chan) {
+        case PS_CHANNEL_RGB:
             qstring_append(reg, ".rgb");
-        }
-        break;
-    case PS_CHANNEL_ALPHA:
-        if (is_alpha) {
-            qstring_append(reg, ".a");
-        } else {
+            break;
+        case PS_CHANNEL_ALPHA:
             qstring_append(reg, ".aaa");
+            break;
+        default:
+            assert(false);
+            break;
         }
-        break;
-    default:
-        assert(false);
-        break;
+    } else {
+        switch (in.chan) {
+        case PS_CHANNEL_BLUE:
+            qstring_append(reg, ".b");
+            break;
+        case PS_CHANNEL_ALPHA:
+            qstring_append(reg, ".a");
+            break;
+        default:
+            assert(false);
+            break;
+        }
     }
 
     QString *res;

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -235,7 +235,7 @@ static QString* get_var(struct PixelShader *ps, int reg, bool is_dest)
         if (is_dest) {
             return qstring_from_str("");
         } else {
-            return qstring_from_str("0.0");
+            return qstring_from_str("vec4(0.0)");
         }
         break;
     case PS_REGISTER_C0:
@@ -280,9 +280,10 @@ static QString* get_var(struct PixelShader *ps, int reg, bool is_dest)
         return qstring_from_str("r1");
     case PS_REGISTER_V1R0_SUM:
         add_var_ref(ps, "r0");
-        return qstring_from_str("(v1 + r0)");
+        return qstring_from_str("vec4(v1.rgb + r0.rgb, 0.0)");
     case PS_REGISTER_EF_PROD:
-        return qstring_from_fmt("(%s * %s)", qstring_get_str(ps->varE),
+        return qstring_from_fmt("vec4(%s * %s, 0.0)",
+                                qstring_get_str(ps->varE),
                                 qstring_get_str(ps->varF));
     default:
         assert(false);
@@ -295,28 +296,24 @@ static QString* get_input_var(struct PixelShader *ps, struct InputInfo in, bool 
 {
     QString *reg = get_var(ps, in.reg, false);
 
-    if (strcmp(qstring_get_str(reg), "0.0") != 0
-        && (in.reg != PS_REGISTER_EF_PROD
-            || strstr(qstring_get_str(reg), ".a") == NULL)) {
-        switch (in.chan) {
-        case PS_CHANNEL_RGB:
-            if (is_alpha) {
-                qstring_append(reg, ".b");
-            } else {
-                qstring_append(reg, ".rgb");
-            }
-            break;
-        case PS_CHANNEL_ALPHA:
-            if (is_alpha) {
-                qstring_append(reg, ".a");
-            } else {
-                qstring_append(reg, ".aaa");
-            }
-            break;
-        default:
-            assert(false);
-            break;
+    switch (in.chan) {
+    case PS_CHANNEL_RGB:
+        if (is_alpha) {
+            qstring_append(reg, ".b");
+        } else {
+            qstring_append(reg, ".rgb");
         }
+        break;
+    case PS_CHANNEL_ALPHA:
+        if (is_alpha) {
+            qstring_append(reg, ".a");
+        } else {
+            qstring_append(reg, ".aaa");
+        }
+        break;
+    default:
+        assert(false);
+        break;
     }
 
     QString *res;

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -307,7 +307,11 @@ static QString* get_input_var(struct PixelShader *ps, struct InputInfo in, bool 
             }
             break;
         case PS_CHANNEL_ALPHA:
-            qstring_append(reg, ".a");
+            if (is_alpha) {
+                qstring_append(reg, ".a");
+            } else {
+                qstring_append(reg, ".aaa");
+            }
             break;
         default:
             assert(false);

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -486,13 +486,12 @@ static void add_final_stage_code(struct PixelShader *ps, struct FCInputInfo fina
     QString *b = get_input_var(ps, final.b, false);
     QString *c = get_input_var(ps, final.c, false);
     QString *d = get_input_var(ps, final.d, false);
-    QString *g = get_input_var(ps, final.g, false);
+    QString *g = get_input_var(ps, final.g, true);
 
     qstring_append_fmt(ps->code, "fragColor.rgb = %s + mix(vec3(%s), vec3(%s), vec3(%s));\n",
                        qstring_get_str(d), qstring_get_str(c),
                        qstring_get_str(b), qstring_get_str(a));
-    /* FIXME: Is .x correctly here? */
-    qstring_append_fmt(ps->code, "fragColor.a = vec3(%s).x;\n", qstring_get_str(g));
+    qstring_append_fmt(ps->code, "fragColor.a = %s;\n", qstring_get_str(g));
 
     qobject_unref(a);
     qobject_unref(b);


### PR DESCRIPTION
Minor changes to our PSH code.

G should be an alpha component, as specified in [NV_register_combiners](https://www.khronos.org/registry/OpenGL/extensions/NV/NV_register_combiners.txt):

> The variable G is an alpha scalar.

I've changed the types to make this safer, this includes the pseudo-registers:

> The alpha component of E_TIMES_F_NV and SPARE0_PLUS_SECONDARY_COLOR_NV is always zero.

There's still a lot of hacky code left, such as casts to `vec3`, so this *does not* solve #202, yet.
That will be solved in a more complicated follow-up.

---

I did only test this with the dashboard and Smashing Drive. The final version I'm sending as PR **already contains some last-minute fixups and was never tested**; I'll run tests during review.

**Should be tested with a handful of games to make sure nothing breaks due to type changes.**