### PR TITLE
psh: Use output clamping from NV_register_combiners GL extension

### DIFF
--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -420,7 +420,7 @@ static void add_stage_code(struct PixelShader *ps,
     QString *sum_dest = get_var(ps, output.muxsum, true);
 
     if (qstring_get_length(ab_dest)) {
-        qstring_append_fmt(ps->code, "%s.%s = %s(%s);\n",
+        qstring_append_fmt(ps->code, "%s.%s = clamp(%s(%s), -1.0, 1.0);\n",
                            qstring_get_str(ab_dest), write_mask, caster, qstring_get_str(ab_mapping));
     } else {
         qobject_unref(ab_dest);
@@ -429,7 +429,7 @@ static void add_stage_code(struct PixelShader *ps,
     }
 
     if (qstring_get_length(cd_dest)) {
-        qstring_append_fmt(ps->code, "%s.%s = %s(%s);\n",
+        qstring_append_fmt(ps->code, "%s.%s = clamp(%s(%s), -1.0, 1.0);\n",
                            qstring_get_str(cd_dest), write_mask, caster, qstring_get_str(cd_mapping));
     } else {
         qobject_unref(cd_dest);
@@ -456,7 +456,7 @@ static void add_stage_code(struct PixelShader *ps,
 
     QString *sum_mapping = get_output(sum, output.mapping);
     if (qstring_get_length(sum_dest)) {
-        qstring_append_fmt(ps->code, "%s.%s = %s(%s);\n",
+        qstring_append_fmt(ps->code, "%s.%s = clamp(%s(%s), -1.0, 1.0);\n",
                            qstring_get_str(sum_dest), write_mask, caster, qstring_get_str(sum_mapping));
     }
 


### PR DESCRIPTION
[This should be closer to NV_register_combiners](https://www.khronos.org/registry/OpenGL/extensions/NV/NV_register_combiners.txt).

I've had this code for a while and never bothered to fully test or PR it.

So this needs a bit of testing - but I assume it's correct.