### PR TITLE
nv2a: Slot 0 of SET_VERTEX_DATA specifies a vertex

### DIFF
--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -2177,7 +2177,6 @@ static void pgraph_method(NV2AState *d,
         attribute->inline_value[3] = 1.0;
         if (slot == 0) {
             pgraph_finish_inline_buffer_vertex(pg);
-            assert(false); /* FIXME: Untested */
         }
         break;
     }
@@ -2192,7 +2191,6 @@ static void pgraph_method(NV2AState *d,
         attribute->inline_value[3] = ((parameter >> 24) & 0xFF) / 255.0;
         if (slot == 0) {
             pgraph_finish_inline_buffer_vertex(pg);
-            assert(false); /* FIXME: Untested */
         }
         break;
     }
@@ -2211,7 +2209,6 @@ static void pgraph_method(NV2AState *d,
                                                      * 2.0 + 1) / 65535.0;
         if ((slot == 0) && (part == 1)) {
             pgraph_finish_inline_buffer_vertex(pg);
-            assert(false); /* FIXME: Untested */
         }
         break;
     }


### PR DESCRIPTION
`NV097_SET_VERTEX_DATA2S` was fixed recently, but it still didn't specify a vertex when setting slot 0. I have now tested with "Conker - Live and Reloaded" and it runs into an assert for that.

I tested the following:

* Disabling the assert and removing the `pgraph_finish_inline_buffer_vertex` call, leads to another assert for `NV097_SET_BEGIN_END`.
* Disabling the assert and keeping `pgraph_finish_inline_buffer_vertex`, fixes the load-screens.

We had previously enabled `pgraph_finish_inline_buffer_vertex` for `NV097_SET_VERTEX_DATA` float types. However, this also seems to apply all other types. I believe it's this part in [NV_vertex_program](https://www.khronos.org/registry/OpenGL/extensions/NV/NV_vertex_program.txt) (2.14.1.1  The Vertex Attribute Registers):

> Vertex program execution is provoked by updating vertex attribute zero.

I've also looked up an equivalent part of the [OpenGL 2.0 specification](https://www.khronos.org/registry/OpenGL/specs/gl/glspec20.pdf) (2.8. VERTEX ARRAYS):

> Setting generic vertex attribute zero specifies a vertex; the four vertex coordinates are taken from the values of attribute zero.  A Vertex2, Vertex3, or Vertex4 command is completely equivalent to the corresponding VertexAttrib*command with an index of zero. 

Where our glVertex{2,3,4} is `NV097_SET_VERTEX<count><type>` and VertexAttrib* is equivalent to`NV097_SET_VERTEX_DATA<count><type>`.

---

**Note:**

The code for `NV097_SET_VERTEX_DATA4S_M` will still be unreachable, as the data parser has not been tested yet - we can still safely assume vertex submission on part 3.