### PR TITLE
Support PGRAPH RDI

### DIFF
--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -305,6 +305,10 @@ static uint32_t pgraph_rdi_read(PGRAPHState *pg,
 {
     uint32_t r = 0;
     switch(select) {
+    case RDI_INDEX_VTX_CONSTANTS0:
+        assert((address / 4) < NV2A_VERTEXSHADER_CONSTANTS);
+        r = pg->vsh_constants[address / 4][3 - address % 4];
+        break;
     default:
         fprintf(stderr, "nv2a: unknown rdi read select 0x%x address 0x%x\n",
                 select, address);
@@ -319,6 +323,13 @@ static void pgraph_rdi_write(PGRAPHState *pg,
                              uint32_t val)
 {
     switch(select) {
+    case RDI_INDEX_VTX_CONSTANTS0:
+        assert(false); /* Untested */
+        assert((address / 4) < NV2A_VERTEXSHADER_CONSTANTS);
+        pg->vsh_constants_dirty[address / 4] |=
+            (val != pg->vsh_constants[address / 4][3 - address % 4]);
+        pg->vsh_constants[address / 4][3 - address % 4] = val;
+        break;
     default:
         NV2A_DPRINTF("unknown rdi write select 0x%x, address 0x%x, val 0x%08x\n",
                      select, address, val);

--- a/hw/xbox/nv2a/nv2a_pgraph.c
+++ b/hw/xbox/nv2a/nv2a_pgraph.c
@@ -306,6 +306,7 @@ static uint32_t pgraph_rdi_read(PGRAPHState *pg,
     uint32_t r = 0;
     switch(select) {
     case RDI_INDEX_VTX_CONSTANTS0:
+    case RDI_INDEX_VTX_CONSTANTS1:
         assert((address / 4) < NV2A_VERTEXSHADER_CONSTANTS);
         r = pg->vsh_constants[address / 4][3 - address % 4];
         break;
@@ -324,6 +325,7 @@ static void pgraph_rdi_write(PGRAPHState *pg,
 {
     switch(select) {
     case RDI_INDEX_VTX_CONSTANTS0:
+    case RDI_INDEX_VTX_CONSTANTS1:
         assert(false); /* Untested */
         assert((address / 4) < NV2A_VERTEXSHADER_CONSTANTS);
         pg->vsh_constants_dirty[address / 4] |=

--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -1286,6 +1286,13 @@
 #define NV_IGRAPH_XF_LTC1_L6                         0x12
 #define NV_IGRAPH_XF_LTC1_L7                         0x13
 
+/* These RDI select values appear to be named by MS.
+ * nvidia seems to refer to RDI_INDEX_VTX_CONSTANTS0 by RDI_RAMSEL_XL_XFCTX.
+ * However, we don't have other nvidia names; so we use these aliases for now.
+ * Eventually we'll probably adopt nouveau names for these internals.
+ */
+#define RDI_INDEX_VTX_CONSTANTS0                     0x17
+
 
 #define NV2A_VERTEX_ATTR_POSITION       0
 #define NV2A_VERTEX_ATTR_WEIGHT         1

--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -1292,6 +1292,7 @@
  * Eventually we'll probably adopt nouveau names for these internals.
  */
 #define RDI_INDEX_VTX_CONSTANTS0                     0x17
+#define RDI_INDEX_VTX_CONSTANTS1                     0xCC
 
 
 #define NV2A_VERTEX_ATTR_POSITION       0

--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -256,6 +256,10 @@
 #   define NV_PGRAPH_INCREMENT_READ_3D                          (1 << 1)
 #define NV_PGRAPH_FIFO                                   0x00000720
 #   define NV_PGRAPH_FIFO_ACCESS                                (1 << 0)
+#define NV_PGRAPH_RDI_INDEX                              0x00000750
+#   define NV_PGRAPH_RDI_INDEX_ADDRESS                        0x00001FFC
+#   define NV_PGRAPH_RDI_INDEX_SELECT                         0x01FF0000
+#define NV_PGRAPH_RDI_DATA                               0x00000754
 #define NV_PGRAPH_CHANNEL_CTX_TABLE                      0x00000780
 #   define NV_PGRAPH_CHANNEL_CTX_TABLE_INST                   0x0000FFFF
 #define NV_PGRAPH_CHANNEL_CTX_POINTER                    0x00000784


### PR DESCRIPTION
This implements the PGRAPH RDI.
RDI is an interface to access the RAM of PGRAPH. We might also PFB RDI in the future, but this is not implemented here.

On hardware, the GPU has to be idle before RDI can be used (apparently RDI shares some address lines with other GPU features). For now, this restriction will not be emulated in XQEMU. We can always make it more accurate in the future.

PGRAPH RDI is irrelevant for game emulation, because D3D drivers use it for features we probably don't need to emulate (optimization, debugging, ..). However, nv2a-trace will depend on this functionality, as some states can not be accessed through other interfaces.

I chose to silently ignore write, unless debug mode is used. The fact that D3D uses this prevents us from `assert(false)` on *writes*.
I chose to `assert('false')` on *reads*, because it would put emulation at risk if something bad is returned. Fortunately D3D doesn't seem to read either.

I've added code for `select` 0x17 and 0xCC as example, which access vertex program constants. They mostly seem to access the same data (probably for 2 separate transform-engines) and I doubt we'll have to emulate these banks going out of sync.

After merge, I'll create issues about other `select` values which will be required for this feature to be useful. Issues will only focus on those features we need, not completeness.

**This should be tested to avoid accidental `assert`. I've only done little testing with the MS dashboard and nothing else.**