### PR TITLE
build.sh: Disable GlusterFS support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -87,6 +87,7 @@ set -x # Print commands from now on
     --disable-spice \
     --disable-user \
     --disable-stack-protector \
+    --disable-glusterfs \
     ${user_opts}
 
 time make -j"${job_count}" 2>&1 | tee build.log


### PR DESCRIPTION
Building GlusterFS support has been broken for a while now (at least on Arch, error log [here](https://pastebin.com/qfxdgUkh)).

xqemu doesn't require it anyway, so this disables GlusterFS in build.sh.