### PR TITLE
ci: Fix MSYS2 upgrade process for AppVeyor

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -9,8 +9,8 @@ rem Set the paths appropriately
 PATH C:\msys64\%MSYSTEM%\bin;C:\msys64\usr\bin;%PATH%
 
 rem Upgrade the MSYS2 platform
-bash -lc "pacman --noconfirm --sync --refresh --refresh pacman"
-bash -lc "pacman --noconfirm --sync --refresh --refresh --sysupgrade --sysupgrade"
+bash -lc "pacman --noconfirm -Syu"
+bash -lc "pacman --noconfirm -Su"
 
 rem Install required tools
 bash -xlc "pacman --noconfirm -S --needed base-devel"


### PR DESCRIPTION
As stated in #221 the build script for appveyor wasn't completing the upgrade process for MSYS2 which caused a lib to become out of sync and not update. This PR fixes this by following the upgrade process recommended on MSYS2 website.

Fixes #221.