### PR TITLE
build: Disable unused features

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,15 +71,18 @@ set -x # Print commands from now on
     ${debug_opts} \
     ${sys_opts} \
     --target-list=i386-softmmu \
+    --enable-trace-backends="nop" \
     --enable-sdl \
     --with-sdlabi=2.0 \
     --disable-curl \
     --disable-vnc \
+    --disable-vnc-sasl \
     --disable-docs \
     --disable-tools \
     --disable-guest-agent \
     --disable-tpm \
     --disable-live-block-migration \
+    --disable-rdma \
     --disable-replication \
     --disable-capstone \
     --disable-fdt \
@@ -88,6 +91,29 @@ set -x # Print commands from now on
     --disable-user \
     --disable-stack-protector \
     --disable-glusterfs \
+    --disable-bluez \
+    --disable-gtk \
+    --disable-curses \
+    --disable-gnutls \
+    --disable-nettle \
+    --disable-gcrypt \
+    --disable-crypto-afalg \
+    --disable-virglrenderer \
+    --disable-vhost-net \
+    --disable-vhost-crypto \
+    --disable-vhost-vsock \
+    --disable-vhost-user \
+    --disable-virtfs \
+    --disable-libssh2 \
+    --disable-snappy \
+    --disable-bzip2 \
+    --disable-vde \
+    --disable-libxml2 \
+    --disable-seccomp \
+    --disable-numa \
+    --disable-lzo \
+    --disable-smartcard \
+    --disable-usb-redir \
     ${user_opts}
 
 time make -j"${job_count}" 2>&1 | tee build.log


### PR DESCRIPTION
This attempts to use many unused or rarely used features.
I looked at the libraries that are linked to XQEMU and then tried to find the corresponding `configure` options.
I usually removed them if I believed there wouldn't be a performance impact, or that the feature isn't useful in the context of Xbox emulation.

There are *some* interesting features, which might be useful for some developers, and maybe even users. However, we don't currently provide documentation for those features, and they are niche use cases (like USB forwarding via network).

This was sloppily thrown together and I considered a draft PR, but we can fix issues during review.
Expect poor code quality and issues in the initial review phase.

---

In particular, this removes stuff like bluetooth support, virtualization features, certain compression algorithms which are used in niche filesystems, GTK UI, curses UI, smartcard support, NUMA support.

I believe this removes the following libraries from the linker (on Linux):

- latk-1.0
- lbluetooth
- lbz2
- lcacard
- lgdk-3
- lgdk_pixbuf-2.0
- lgnutls
- lgtk-3
- llzo2
- lncursesw
- lnettle
- lnfs
- lnuma
- lpango-1.0
- lpangocairo-1.0
- lpcre2-8
- lrados
- lrbd
- lrt
- lseccomp
- lsnappy
- lssh2
- lusbredirparser
- lutil
- lvdeplug
- lvirglrenderer
- lvte-2.91
- lxml2

So this helps with keeping fewer dependencies and should increase compilation speed.

---

For review:

- We have to make sure that it still compiles on all platforms (and CI).
- We have to check if CI might install packages that are no longer necessary; we should keep notes for documentation.
- If other useless features are being noticed, bring them up so I can add them.
- There shouldn't be any redundant or conflicting options in build.sh.
- Users should verify there's no performance loss.