### PR TITLE
ci: Fix compiling with macOS on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
   - osx
 
 python:
-  - "2.6"
+  - "3.7"
 
 compiler:
   - gcc
@@ -42,14 +42,17 @@ addons:
       - uuid-dev
       - libsdl2-dev
       - libepoxy-dev
+  homebrew:
+    packages:
+      - glib
+      - pixman
+      - sdl2
+      - libepoxy
+
 
 git:
   # we want to do this ourselves
   submodules: false
-
-before_install:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update ; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install libffi gettext glib pixman pkg-config autoconf pixman sdl2 libepoxy; fi
 
 script:
   - ./build.sh


### PR DESCRIPTION
macOS has been broken for some time due to updated packages, we should be using what travis-ci gives us via similar scripts as to what we currently use for linux with the same provider.

I also updated the python version to 3.7, however I'm not sure this actually effects anything as both versions build fine.