### PR TITLE
ci: Stop updating the MSYS2 platform on AppVeyor

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -8,10 +8,6 @@ rem    MSYSTEM:  MINGW64 or MINGW32
 rem Set the paths appropriately
 PATH C:\msys64\%MSYSTEM%\bin;C:\msys64\usr\bin;%PATH%
 
-rem Upgrade the MSYS2 platform
-bash -lc "pacman --noconfirm -Syu"
-bash -lc "pacman --noconfirm -Su"
-
 rem Install required tools
 bash -xlc "pacman --noconfirm -S --needed base-devel"
 


### PR DESCRIPTION
#222 was supposed to fix #221 however it seems that during the time it took between the PR and merge MSYS2 updated *something* which broke building again. So from now on we wont update MSYS and let AppVeyor handle keeping packages up-to-date like we currently do with travis.