### PR TITLE
eeprom: Implement writeback

### DIFF
--- a/hw/i2c/smbus_eeprom.c
+++ b/hw/i2c/smbus_eeprom.c
@@ -26,6 +26,7 @@
 #include "hw/hw.h"
 #include "hw/i2c/i2c.h"
 #include "hw/i2c/smbus.h"
+#include "hw/xbox/xbox.h"
 
 //#define DEBUG
 
@@ -84,6 +85,8 @@ static void eeprom_write_data(SMBusDevice *dev, uint8_t cmd, uint8_t *buf, int l
     len -= n;
     if (len)
         memcpy(eeprom->data, buf + n, len);
+
+    save_eeprom(eeprom->data);
 }
 
 static uint8_t eeprom_read_data(SMBusDevice *dev, uint8_t cmd, int n)

--- a/hw/xbox/xbox.h
+++ b/hw/xbox/xbox.h
@@ -22,10 +22,12 @@
 #define HW_XBOX_H
 
 #include "hw/boards.h"
+#include "hw/i386/pc.h"
 
 #define MAX_IDE_BUS 2
 
-uint8_t *load_eeprom(void);
+uint8_t *load_eeprom(MachineState *machine);
+void save_eeprom(uint8_t *eeprom_data);
 
 void xbox_init_common(MachineState *machine,
                       const uint8_t *eeprom,
@@ -43,6 +45,7 @@ void xbox_init_common(MachineState *machine,
 typedef struct XboxMachineState {
     /*< private >*/
     PCMachineState parent_obj;
+    int eeprom_fd;
 
     /*< public >*/
     char *bootrom;


### PR DESCRIPTION
This is my own take on EEPROM writeback, based on the review comments on #122.
I see two remaining issues with my code:
1. It leaks the file descriptor (afaik this was also an issue in #122), because I couldn't spot a good place where I could put a `close()` (there seems to be no "destructor" for `MachineState`).
2. Saving the EEPROM is still done in a global function in xbox.c (criticized by @JayFoxRox). I intended to solve this by passing the file descriptor to the EEPROM device, but doing this properly would require work that is far over my head (this is the first time I'm touching qemu internals)