### PR TITLE
Fix for building on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ addons:
       - libsdl2-dev
       - libepoxy-dev
   homebrew:
+    update: true
     packages:
       - glib
       - pixman

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,8 @@ case "$(uname -s)" in # adjust compilation option based on platform
         echo 'Compiling for MacOS…'
         sys_cflags='-march=native'
         sys_opts='--disable-cocoa'
+        # necessary to find libffi, which is required by gobject
+        export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}/usr/local/opt/libffi/lib/pkgconfig"
         ;;
     CYGWIN*|MINGW*|MSYS*)
         echo 'Compiling for Windows…'


### PR DESCRIPTION
The problems we currently experience when building on macOS are caused by pkg-config not finding `libffi.pc`, which is a requirement for `pkg-config` to find `gobject-2.0`. libffi is not symlinked into `/usr/local` by homebrew on purpose, so we must add the path to `libffi.pc` to the `PKG_CONFIG_PATH` environment variable (this is the solution recommended by homebrew when installing libffi).

It seems that XQEMU doesn't actually require libffi when building, otherwise we'd have to add `/usr/local/opt/libffi/lib` to the libary search directories as well.

Building tested on macOS, building and running tested on Arch.

Closes #239.