### PR TITLE
Audio PR #3: Connect VP output directly into system audio

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,19 +42,19 @@ case "$(uname -s)" in # adjust compilation option based on platform
     Linux)
         echo 'Compiling for Linux…'
         sys_cflags='-march=native -Wno-error=redundant-decls -Wno-error=unused-but-set-variable'
-        sys_opts='--enable-kvm --disable-xen --disable-werror'
+        sys_opts='--enable-kvm --disable-xen --disable-werror --audio-drv-list=alsa'
         ;;
     Darwin)
         echo 'Compiling for MacOS…'
         sys_cflags='-march=native'
-        sys_opts='--disable-cocoa'
+        sys_opts='--disable-cocoa --audio-drv-list=coreaudio'
         # necessary to find libffi, which is required by gobject
         export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}/usr/local/opt/libffi/lib/pkgconfig"
         ;;
     CYGWIN*|MINGW*|MSYS*)
         echo 'Compiling for Windows…'
         sys_cflags='-Wno-error'
-        sys_opts='--python=python3 --disable-cocoa --disable-opengl'
+        sys_opts='--python=python3 --disable-cocoa --disable-opengl --audio-drv-list=dsound'
         postbuild='package_windows' # set the above function to be called after build
         ;;
     *)

--- a/hw/xbox/mcpx_apu.c
+++ b/hw/xbox/mcpx_apu.c
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2012 espes
  * Copyright (c) 2018-2019 Jannik Vogel
+ * Copyright (c) 2019 Matt Borgerson
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -433,7 +434,7 @@ static void mcpx_apu_write(void *opaque, hwaddr addr,
             timer_del(d->se.frame_timer);
         } else {
             timer_mod(d->se.frame_timer,
-                qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL) + 10);
+                qemu_clock_get_us(QEMU_CLOCK_VIRTUAL) + 600);
         }
         d->regs[addr] = val;
         break;
@@ -1478,7 +1479,7 @@ static void se_frame(void *opaque)
     int mixbin;
     int sample;
 
-    timer_mod(d->se.frame_timer, qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL) + 10);
+    timer_mod(d->se.frame_timer, qemu_clock_get_us(QEMU_CLOCK_VIRTUAL) + 600);
     MCPX_DPRINTF("mcpx frame ping\n");
 
     /* Buffer for all mixbins for this frame */

--- a/hw/xbox/mcpx_apu.c
+++ b/hw/xbox/mcpx_apu.c
@@ -28,6 +28,7 @@
 #include <math.h>
 
 #define USE_APU_THREAD 1
+#define PROCESS_VOICES 0
 
 #define NUM_SAMPLES_PER_FRAME 32
 #define NUM_MIXBINS 32
@@ -1148,7 +1149,7 @@ static const MemoryRegionOps ep_ops = {
     .write = ep_write,
 };
 
-#if 0
+#if PROCESS_VOICES
 #include "adpcm_block.h"
 
 static hwaddr get_data_ptr(hwaddr sge_base, unsigned int max_sge, uint32_t addr) {
@@ -1289,7 +1290,7 @@ static void process_voice(MCPXAPUState *d,
                           int32_t mixbins[NUM_MIXBINS][NUM_SAMPLES_PER_FRAME],
                           uint32_t voice)
 {
-#if 0
+#if PROCESS_VOICES
     uint32_t v = voice;
     int32_t samples[2][0x20] = {0};
 

--- a/hw/xbox/mcpx_apu.c
+++ b/hw/xbox/mcpx_apu.c
@@ -1383,8 +1383,8 @@ static void process_voice(MCPXAPUState *d,
                 //FIXME: Used wrong sample format in my own decoder.. stupid me lol
                 int16_t tmp[2];
                 adpcm_decode_stereo_block(&tmp[0], &tmp[1], (uint8_t*)block, block_position, block_position);
-                samples[0][i] = tmp[0];
-                samples[1][i] = tmp[1];
+                samples[0][i] = tmp[0] << 16;
+                samples[1][i] = tmp[1] << 16;
             } else {
                 assert(samples_per_block == 1);
                 // There are 65 samples per 36 byte block
@@ -1398,7 +1398,7 @@ static void process_voice(MCPXAPUState *d,
                 //FIXME: Used wrong sample format in my own decoder.. stupid me lol
                 int16_t tmp;
                 adpcm_decode_mono_block(&tmp, (uint8_t*)block, block_position, block_position);
-                samples[0][i] = tmp;
+                samples[0][i] = tmp << 16;
             }
 
         } else {
@@ -1415,13 +1415,13 @@ static void process_voice(MCPXAPUState *d,
             for(unsigned int channel = 0; channel < channels; channel++) {
                 switch(sample_size) {
                 case NV_PAVS_VOICE_CFG_FMT_SAMPLE_SIZE_U8:
-                    samples[channel][i] = ldub_phys(&address_space_memory, addr);
+                    samples[channel][i] = ldub_phys(&address_space_memory, addr) << 24;
                     break;
                 case NV_PAVS_VOICE_CFG_FMT_SAMPLE_SIZE_S16:
-                    samples[channel][i] = (int16_t)lduw_le_phys(&address_space_memory, addr);
+                    samples[channel][i] = (int16_t)lduw_le_phys(&address_space_memory, addr) << 16;
                     break;
                 case NV_PAVS_VOICE_CFG_FMT_SAMPLE_SIZE_S24:
-                    samples[channel][i] = (int32_t)(ldl_le_phys(&address_space_memory, addr) << 8) >> 8;
+                    samples[channel][i] = (int32_t)(ldl_le_phys(&address_space_memory, addr) ) << 8;
                     break;
                 case NV_PAVS_VOICE_CFG_FMT_SAMPLE_SIZE_S32:
                     samples[channel][i] = (int32_t)ldl_le_phys(&address_space_memory, addr);


### PR DESCRIPTION
Note: This PR is part of a series of PRs coming to add basic audio.

---

This patch gets *very* basic audio working in XQEMU by feeding the
output of the VP directly into system audio through the QEMU sound
architecture.

Note: the audio coming out of the VP is not fully mixed, and this patch
mixes all voices down to a single channel to keep things simple for now.
Currently, only buffers are played, streamed audio is not yet supported.
This may cause some games to hang. Furthermore, the DSP is not involved
here yet, so in addition to poor mixing, some audio may be horribly
broken.

Processing of individual voices is turned off in this patch to avoid regressions with games
until I follow up with the streaming PR. To test, set the `PROCESS_VOICES`
macro in mcpx_apu.c to 1.