### PR TITLE
build: Use bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ BUILD_DIR=$(CURDIR)
 # Before including a proper config-host.mak, assume we are in the source tree
 SRC_PATH=.
 
+# Use bash as sh if-statement evaluation is wonky
+SHELL := /usr/bin/env bash
+
 UNCHECKED_GOALS := %clean TAGS cscope ctags dist \
     html info pdf txt \
     help check-help print-% \


### PR DESCRIPTION
`sh` evaluation of expressions is wonky.
`! expression` evaluates to the same as `expression` in `sh` which makes the dirty-check ineffective on some systems.

Tested locally on Debian Linux, works fine.
Would appreciate if someone could test the AppVeyor artifact on Windows and of course building it locally on both Windows and macOS.