### PR TITLE
nv2a: Fix VGA get_bpp for X1R5G5B5

### DIFF
--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -330,6 +330,7 @@ typedef struct NV2AState {
         uint64_t core_clock_freq;
         uint32_t memory_clock_coeff;
         uint32_t video_clock_coeff;
+        uint32_t general_control;
     } pramdac;
 
 } NV2AState;

--- a/hw/xbox/nv2a/nv2a_pramdac.c
+++ b/hw/xbox/nv2a/nv2a_pramdac.c
@@ -41,6 +41,9 @@ uint64_t pramdac_read(void *opaque, hwaddr addr, unsigned int size)
              | NV_PRAMDAC_PLL_TEST_COUNTER_MPLL_LOCK
              | NV_PRAMDAC_PLL_TEST_COUNTER_VPLL_LOCK;
         break;
+    case NV_PRAMDAC_GENERAL_CONTROL:
+        r = d->pramdac.general_control;
+        break;
     default:
         break;
     }
@@ -80,6 +83,9 @@ void pramdac_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
         break;
     case NV_PRAMDAC_VPLL_COEFF:
         d->pramdac.video_clock_coeff = val;
+        break;
+    case NV_PRAMDAC_GENERAL_CONTROL:
+        d->pramdac.general_control = val;
         break;
     default:
         break;

--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -674,7 +674,8 @@
 #   define NV_PRAMDAC_PLL_TEST_COUNTER_NVPLL_LOCK              (1 << 29)
 #   define NV_PRAMDAC_PLL_TEST_COUNTER_MPLL_LOCK               (1 << 30)
 #   define NV_PRAMDAC_PLL_TEST_COUNTER_VPLL_LOCK               (1 << 31)
-
+#define NV_PRAMDAC_GENERAL_CONTROL                       0x00000600
+#   define NV_PRAMDAC_GENERAL_CONTROL_ALT_MODE_SEL             (1 << 12)
 
 #define NV_USER_DMA_PUT                                  0x40
 #define NV_USER_DMA_GET                                  0x44


### PR DESCRIPTION
Closes #241 

This PR changes `nv2a_get_bpp`, so it also respects a RAMDAC configuration bit which decides wether to decode bits as X1R5G5B5 or R5G6B5.

The RAMDAC configuration bit was found using reverse engineering, but then [confirmed by matching code in the linux kernel](https://github.com/torvalds/linux/blob/851ca779d110f694b5d078bc4af06d3ad37169e8/drivers/gpu/drm/nouveau/dispnv04/crtc.c#L588-L589) (our old code only handled [this linux equivalent](https://github.com/torvalds/linux/blob/851ca779d110f694b5d078bc4af06d3ad37169e8/drivers/gpu/drm/nouveau/dispnv04/crtc.c#L574)).

A switch-case is now used to map modes from `CR[0x28]` to pseudo-magic bpp values for QEMU.

---

The resulting image will look fine:

![Screenshot of fixed rendering](https://media.discordapp.net/attachments/539592559870214145/593324649484386309/2019-06-26-081540_648x506_scrot.png)

Fixes Fable, and other games which use X1R5G5B5.

---

I was originally going to wait until nxdk had support for this (https://github.com/XboxDev/nxdk/pull/141 and follow-up PRs) but there was little review process in the past 3 months.
Because of that, Fable will still hit an assert for an untested color-clear (#213); I'll submit a separate PR once I have tested that feature independently.

Due to this massive delay, I also wasn't able to keep my Fable dump around, so I was unable to repeat my tests.
The above screenshot is very old and the code has been refactored since then.
Therefore this PR needs testing of Fable or another X1R5G5B5 application.