### PR TITLE
nv2a: Add some missing RAMDAC registers

### DIFF
--- a/hw/xbox/nv2a/nv2a_int.h
+++ b/hw/xbox/nv2a/nv2a_int.h
@@ -331,6 +331,13 @@ typedef struct NV2AState {
         uint32_t memory_clock_coeff;
         uint32_t video_clock_coeff;
         uint32_t general_control;
+        uint32_t fp_vdisplay_end;
+        uint32_t fp_vcrtc;
+        uint32_t fp_vsync_end;
+        uint32_t fp_vvalid_end;
+        uint32_t fp_hdisplay_end;
+        uint32_t fp_hcrtc;
+        uint32_t fp_hvalid_end;
     } pramdac;
 
 } NV2AState;

--- a/hw/xbox/nv2a/nv2a_pramdac.c
+++ b/hw/xbox/nv2a/nv2a_pramdac.c
@@ -44,6 +44,27 @@ uint64_t pramdac_read(void *opaque, hwaddr addr, unsigned int size)
     case NV_PRAMDAC_GENERAL_CONTROL:
         r = d->pramdac.general_control;
         break;
+    case NV_PRAMDAC_FP_VDISPLAY_END:
+        r = d->pramdac.fp_vdisplay_end;
+        break;
+    case NV_PRAMDAC_FP_VCRTC:
+        r = d->pramdac.fp_vcrtc;
+        break;
+    case NV_PRAMDAC_FP_VSYNC_END:
+        r = d->pramdac.fp_vsync_end;
+        break;
+    case NV_PRAMDAC_FP_VVALID_END:
+        r = d->pramdac.fp_vvalid_end;
+        break;
+    case NV_PRAMDAC_FP_HDISPLAY_END:
+        r = d->pramdac.fp_hdisplay_end;
+        break;
+    case NV_PRAMDAC_FP_HCRTC:
+        r = d->pramdac.fp_hcrtc;
+        break;
+    case NV_PRAMDAC_FP_HVALID_END:
+        r = d->pramdac.fp_hvalid_end;
+        break;
     default:
         break;
     }
@@ -86,6 +107,27 @@ void pramdac_write(void *opaque, hwaddr addr, uint64_t val, unsigned int size)
         break;
     case NV_PRAMDAC_GENERAL_CONTROL:
         d->pramdac.general_control = val;
+        break;
+    case NV_PRAMDAC_FP_VDISPLAY_END:
+        d->pramdac.fp_vdisplay_end = val;
+        break;
+    case NV_PRAMDAC_FP_VCRTC:
+        d->pramdac.fp_vcrtc = val;
+        break;
+    case NV_PRAMDAC_FP_VSYNC_END:
+        d->pramdac.fp_vsync_end = val;
+        break;
+    case NV_PRAMDAC_FP_VVALID_END:
+        d->pramdac.fp_vvalid_end = val;
+        break;
+    case NV_PRAMDAC_FP_HDISPLAY_END:
+        d->pramdac.fp_hdisplay_end = val;
+        break;
+    case NV_PRAMDAC_FP_HCRTC:
+        d->pramdac.fp_hcrtc = val;
+        break;
+    case NV_PRAMDAC_FP_HVALID_END:
+        d->pramdac.fp_hvalid_end = val;
         break;
     default:
         break;

--- a/hw/xbox/nv2a/nv2a_regs.h
+++ b/hw/xbox/nv2a/nv2a_regs.h
@@ -680,6 +680,13 @@
 #   define NV_PRAMDAC_PLL_TEST_COUNTER_VPLL_LOCK               (1 << 31)
 #define NV_PRAMDAC_GENERAL_CONTROL                       0x00000600
 #   define NV_PRAMDAC_GENERAL_CONTROL_ALT_MODE_SEL             (1 << 12)
+#define NV_PRAMDAC_FP_VDISPLAY_END                       0x00000800
+#define NV_PRAMDAC_FP_VCRTC                              0x00000808
+#define NV_PRAMDAC_FP_VSYNC_END                          0x00000810
+#define NV_PRAMDAC_FP_VVALID_END                         0x00000818
+#define NV_PRAMDAC_FP_HDISPLAY_END                       0x00000820
+#define NV_PRAMDAC_FP_HCRTC                              0x00000828
+#define NV_PRAMDAC_FP_HVALID_END                         0x00000838
 
 #define NV_USER_DMA_PUT                                  0x40
 #define NV_USER_DMA_GET                                  0x44


### PR DESCRIPTION
They are needed to obtain current screen resolution.

![image](https://user-images.githubusercontent.com/578406/66440599-38990300-ea3c-11e9-8f9a-924b629a6e57.png)
