### PR TITLE
Update macOS build script to use GNU compatible greadlink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ addons:
       - pixman
       - sdl2
       - libepoxy
+      - coreutils
 
 git:
   # we want to do this ourselves

--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,7 @@ do
     esac
 done
 
+readlink=$(command -v readlink)
 
 case "$(uname -s)" in # adjust compilation option based on platform
     Linux)
@@ -50,6 +51,13 @@ case "$(uname -s)" in # adjust compilation option based on platform
         sys_opts='--disable-cocoa'
         # necessary to find libffi, which is required by gobject
         export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}/usr/local/opt/libffi/lib/pkgconfig"
+        # macOS needs greadlink for a GNU compatible version of readlink
+        if readlink=$(command -v greadlink); then
+            echo 'GNU compatible readlink detected'
+        else
+            echo 'Could not find a GNU compatible readlink. Please install coreutils with homebrew'
+            exit -1
+        fi
         ;;
     CYGWIN*|MINGW*|MSYS*)
         echo 'Compiling for Windows…'
@@ -64,7 +72,7 @@ case "$(uname -s)" in # adjust compilation option based on platform
 esac
 
 # find absolute path (and resolve symlinks) to build out of tree
-configure="$(dirname "$(readlink -f "${0}")")/configure"
+configure="$(dirname "$($readlink -f "${0}")")/configure"
 
 set -x # Print commands from now on
 


### PR DESCRIPTION
Small change to include `coreutils` in the macOS travis builds and use GNU compatible`greadlink` instead of `readlink` for the macOS platform.

closes https://github.com/xqemu/xqemu/issues/242