### PR TITLE
ci: Unlink python@2 for macOS

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install Dependencies
       run: |
         brew update
+        brew unlink python@2
         brew install \
           glib \
           pixman \


### PR DESCRIPTION
Dependency resolution resulting in installation of 'python' will grab
python@3 which conflicts with existing python@2 installation's symlinks.
Unlink python@2 for now so python@3 can install cleanly.

This might break again in the future if GitHub's base image removes python@2, but should do the trick in the mean time. If it breaks for that reason, we can pull this line out.