### PR TITLE
ci: Switch to checkout v2, ignore irrelevant files

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -1,11 +1,50 @@
 name: Build (macOS)
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/*'
+      - 'docs/*/*'
+      - '.shippable.yml'
+      - '.cirrus.yml'
+      - '.gitlab-ci.yml'
+      - '.gitpublish'
+      - '.mailmap'
+      - '.travis.yml'
+      - 'CODING_STYLE'
+      - 'COPYING*'
+      - 'HACKING'
+      - 'LICENSE'
+      - 'MAINTAINERS'
+      - 'qemu.nsi'
+      - '*.texi'
+      - 'README*'
+      - 'VERSION*'
+  pull_request:
+    paths-ignore:
+      - 'docs/*'
+      - 'docs/*/*'
+      - '.shippable.yml'
+      - '.cirrus.yml'
+      - '.gitlab-ci.yml'
+      - '.gitpublish'
+      - '.mailmap'
+      - '.travis.yml'
+      - 'CODING_STYLE'
+      - 'COPYING*'
+      - 'HACKING'
+      - 'LICENSE'
+      - 'MAINTAINERS'
+      - 'qemu.nsi'
+      - '*.texi'
+      - 'README*'
+      - 'VERSION*'
 
 jobs:
   macOS:
     runs-on: macOS-latest
     strategy:
+      fail-fast: false
       matrix:
         configuration: ["Debug", "Release"]
     steps:
@@ -21,9 +60,7 @@ jobs:
           print('::set-env name=BUILD_PARAM::--release')
           print('::set-env name=ARTIFACT_NAME::xqemu-release')
     - name: Clone Tree
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+      uses: actions/checkout@v2
     - name: Install Dependencies
       run: |
         brew update

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -1,11 +1,50 @@
 name: Build (Ubuntu)
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/*'
+      - 'docs/*/*'
+      - '.shippable.yml'
+      - '.cirrus.yml'
+      - '.gitlab-ci.yml'
+      - '.gitpublish'
+      - '.mailmap'
+      - '.travis.yml'
+      - 'CODING_STYLE'
+      - 'COPYING*'
+      - 'HACKING'
+      - 'LICENSE'
+      - 'MAINTAINERS'
+      - 'qemu.nsi'
+      - '*.texi'
+      - 'README*'
+      - 'VERSION*'
+  pull_request:
+    paths-ignore:
+      - 'docs/*'
+      - 'docs/*/*'
+      - '.shippable.yml'
+      - '.cirrus.yml'
+      - '.gitlab-ci.yml'
+      - '.gitpublish'
+      - '.mailmap'
+      - '.travis.yml'
+      - 'CODING_STYLE'
+      - 'COPYING*'
+      - 'HACKING'
+      - 'LICENSE'
+      - 'MAINTAINERS'
+      - 'qemu.nsi'
+      - '*.texi'
+      - 'README*'
+      - 'VERSION*'
 
 jobs:
   Ubuntu:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         configuration: ["Debug", "Release"]
     steps:
@@ -21,9 +60,7 @@ jobs:
           print('::set-env name=BUILD_PARAM::--release')
           print('::set-env name=ARTIFACT_NAME::xqemu-release')
     - name: Clone Tree
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+      uses: actions/checkout@v2
     - name: Install Dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,11 +1,50 @@
 name: Build (Windows)
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/*'
+      - 'docs/*/*'
+      - '.shippable.yml'
+      - '.cirrus.yml'
+      - '.gitlab-ci.yml'
+      - '.gitpublish'
+      - '.mailmap'
+      - '.travis.yml'
+      - 'CODING_STYLE'
+      - 'COPYING*'
+      - 'HACKING'
+      - 'LICENSE'
+      - 'MAINTAINERS'
+      - 'qemu.nsi'
+      - '*.texi'
+      - 'README*'
+      - 'VERSION*'
+  pull_request:
+    paths-ignore:
+      - 'docs/*'
+      - 'docs/*/*'
+      - '.shippable.yml'
+      - '.cirrus.yml'
+      - '.gitlab-ci.yml'
+      - '.gitpublish'
+      - '.mailmap'
+      - '.travis.yml'
+      - 'CODING_STYLE'
+      - 'COPYING*'
+      - 'HACKING'
+      - 'LICENSE'
+      - 'MAINTAINERS'
+      - 'qemu.nsi'
+      - '*.texi'
+      - 'README*'
+      - 'VERSION*'
 
 jobs:
   Windows:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         configuration: ["Debug", "Release"]
     steps:
@@ -21,9 +60,7 @@ jobs:
           print('::set-env name=BUILD_PARAM::--release')
           print('::set-env name=ARTIFACT_NAME::xqemu-release')
     - name: Clone Tree
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+      uses: actions/checkout@v2
     - name: Install Dependencies
       run: |
         echo "Downloading MSYS2 environment..."
@@ -52,7 +89,7 @@ jobs:
         ccache -s -c
         "@
     - name: Upload Build Artifact
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v1
       with:
-        name: ${{env.ARTIFACT_NAME}}
+        name: ${{ env.ARTIFACT_NAME }}
         path: dist


### PR DESCRIPTION
There's probably a few files I missed so feel free to point them out.

---

Disable fail-fast.
fetch-depth: 1 is no longer needed since v2 does this by default.
Use v1 of upload-artifact instead of master, and fix inconsistency with ARTIFACT_NAME.