### PR TITLE
 ci: Remove glib from macOS dep list

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -29,7 +29,6 @@ jobs:
         brew update
         brew unlink python@2
         brew install \
-          glib \
           pixman \
           sdl2 \
           libepoxy \


### PR DESCRIPTION
This fixes the CI builder for MacOS.

This is a change by mborgerson used in his XQEMU based project, unable to cherry-pick easily due to other changes so manually patched.