### PR TITLE
nv2a: Don't normalize light direction

### DIFF
--- a/hw/xbox/nv2a/nv2a_shaders.c
+++ b/hw/xbox/nv2a/nv2a_shaders.c
@@ -535,7 +535,7 @@ GLSL_DEFINE(sceneAmbientColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_FR_AMB) ".xyz")
                     i, i);
                 qstring_append_fmt(body,
                     "  float attenuation = 1.0;\n"
-                    "  float nDotVP = max(0.0, dot(tNormal, normalize(vec3(lightInfiniteDirection%d))));\n"
+                    "  float nDotVP = max(0.0, dot(tNormal, vec3(lightInfiniteDirection%d)));\n"
                     "  float nDotHV = max(0.0, dot(tNormal, vec3(lightInfiniteHalfVector%d)));\n",
                     i, i);
 


### PR DESCRIPTION
This was a bug that I [accidentally found while developing xgu-gl](https://github.com/JayFoxRox/xgu-gl) and testing the [cube.c OpenGL sample from SGI](https://www.opengl.org/archives/resources/code/samples/glut_examples/examples/examples.html).
[On hardware the cube would appear too bright; in XQEMU and in native OpenGL the cube would appear correctly](https://cdn.discordapp.com/attachments/428399682239332354/713834611549012000/2020-05-23-212300_527x340_scrot.png) (the log was made using some modified material parameters; "127.0.0.1" is XQEMU; "192.168.177.3" is my physical Xbox). While this meant I had a bug in xgu-gl, it also meant that XQEMU had a bug where it would significantly deviate from hardware (as XQEMU showed a brighter color than hardware).

I tracked this down to the directional light vector not being normalized in cube.c: it's `{1.0,1.0,1.0}`.
I then tried to normalize it to `{0.577,0.577,0.577}` and that fixed the brightness issue on hardware (XQEMU was unaffected).
This meant that XQEMU must have a normalization which the hardware doesn't do.

This PR removes that normalization.

For real-world applications, this should not make a difference, because D3D and OpenGL probably normalize this vector (I'll add the missing normalization to xgu-gl soon).

Screenshots:
- [Hardware](https://cdn.discordapp.com/attachments/428399682239332354/713814011136835694/hardware-untiled-tiles-color.png) (too bright compared to OpenGL = bug in xgu-gl)
- [XQEMU after PR](https://user-images.githubusercontent.com/360330/82766873-013c6280-9e23-11ea-9611-8d49794eacd3.png) (too bright compared to OpenGL = bug in xgu-gl; matches hardware output)
- [XQEMU before PR](https://cdn.discordapp.com/attachments/428399682239332354/713814014349541406/xqemu-2020-05-23-195840_648x506_scrot.png) (too dark compared to hardware = bug in XQEMU)
- [OpenGL](https://cdn.discordapp.com/attachments/428399682239332354/713814016086114464/opengl-2020-05-23-195959_648x506_scrot.png) (reference)