### PR TITLE
lpc: Replace assertions with warnings

### DIFF
--- a/hw/xbox/lpc47m157.c
+++ b/hw/xbox/lpc47m157.c
@@ -108,10 +108,18 @@ static void lpc47m157_io_write(void *opaque, hwaddr addr, uint64_t val,
     if (addr == 0) {
         /* INDEX_PORT */
         if (val == ENTER_CONFIG_KEY) {
-            assert(!s->configuration_mode);
+            if (s->configuration_mode) {
+                printf("lpc47m157 io write: Attempted to reenter configuration mode\n");
+            }
+            DPRINTF("lpc47m157 io write: Entering configuration mode\n");
+
             s->configuration_mode = true;
         } else if (val == EXIT_CONFIG_KEY) {
-            assert(s->configuration_mode);
+            if (!s->configuration_mode) {
+                printf("lpc47m157 io write: Attempted to reexit configuration mode\n");
+            }
+            DPRINTF("lpc47m157 io write: Exiting configuration mode\n");
+
             s->configuration_mode = false;
 
             update_devices(s);


### PR DESCRIPTION
Third-party software might be buggy and thus trigger these assertions,
however it's not critical and the emulation should not be stopped.

I was able to trigger it by running CPU-Z v1.92 in ReactOS installation.
Without this change XQEMU release build just halts the emulation.

![image](https://user-images.githubusercontent.com/578406/83524242-00bf5e00-a4ec-11ea-8941-7303db408c23.png)

This change is inspired by:
https://github.com/StrikerX3/OpenXBOX/blob/1a3d5fbdda6891ee1b6813a515d973d9f9b35b3d/src/core/openxbox/hw/basic/superio.cpp#L121