### PR TITLE
Improve AC97 for use with nxdk homebrew

### DIFF
--- a/audio/audio.c
+++ b/audio/audio.c
@@ -639,9 +639,7 @@ int audio_pcm_sw_read (SWVoiceIn *sw, void *buf, int size)
         total += isamp;
     }
 
-    if (!(hw->ctl_caps & VOICE_VOLUME_CAP)) {
-        mixeng_volume (sw->buf, ret, &sw->vol);
-    }
+    mixeng_volume (sw->buf, ret, &sw->vol);
 
     sw->clip (buf, sw->buf, ret);
     sw->total_hw_samples_acquired += total;
@@ -726,9 +724,7 @@ int audio_pcm_sw_write (SWVoiceOut *sw, void *buf, int size)
     if (swlim) {
         sw->conv (sw->buf, buf, swlim);
 
-        if (!(sw->hw->ctl_caps & VOICE_VOLUME_CAP)) {
-            mixeng_volume (sw->buf, swlim, &sw->vol);
-        }
+        mixeng_volume (sw->buf, swlim, &sw->vol);
     }
 
     while (swlim) {
@@ -1616,10 +1612,6 @@ void AUD_set_volume_out (SWVoiceOut *sw, int mute, uint8_t lvol, uint8_t rvol)
         sw->vol.mute = mute;
         sw->vol.l = nominal_volume.l * lvol / 255;
         sw->vol.r = nominal_volume.r * rvol / 255;
-
-        if (hw->pcm_ops->ctl_out) {
-            hw->pcm_ops->ctl_out (hw, VOICE_VOLUME, sw);
-        }
     }
 }
 
@@ -1631,10 +1623,6 @@ void AUD_set_volume_in (SWVoiceIn *sw, int mute, uint8_t lvol, uint8_t rvol)
         sw->vol.mute = mute;
         sw->vol.l = nominal_volume.l * lvol / 255;
         sw->vol.r = nominal_volume.r * rvol / 255;
-
-        if (hw->pcm_ops->ctl_in) {
-            hw->pcm_ops->ctl_in (hw, VOICE_VOLUME, sw);
-        }
     }
 }
 

--- a/hw/audio/ac97.c
+++ b/hw/audio/ac97.c
@@ -174,7 +174,7 @@ enum {
     CAS      = 0x34
 };
 
-#define GET_BM(index) (((index) >> 4) & 3)
+#define GET_BM(index) (((index) >> 4) & 7)
 
 static void po_callback (void *opaque, int free);
 static void pi_callback (void *opaque, int avail);

--- a/hw/audio/ac97.c
+++ b/hw/audio/ac97.c
@@ -260,6 +260,7 @@ static void update_sr (AC97LinkState *s, AC97BusMasterRegs *r, uint32_t new_sr)
 
 static void voice_set_active (AC97LinkState *s, int bm_index, int on)
 {
+printf("setting active 0x%X: %d\n", bm_index, on);
     switch (bm_index) {
     case PI_INDEX:
         AUD_set_active_in (s->voice_pi, on);
@@ -296,6 +297,7 @@ static void reset_bm_regs (AC97LinkState *s, AC97BusMasterRegs *r)
     r->cr = r->cr & CR_DONT_CLEAR_MASK;
     r->bd_valid = 0;
 
+printf("bm_reset 0x%X\n", r - s->bm_regs);
     voice_set_active (s, r - s->bm_regs, 0);
     memset (s->silence, 0, sizeof (s->silence));
 }
@@ -338,6 +340,7 @@ static void open_voice (AC97LinkState *s, int index, int freq)
 
     if (freq > 0) {
         s->invalid_freq[index] = 0;
+printf("opening 0x%X\n", index);
         switch (index) {
         case PI_INDEX:
             s->voice_pi = AUD_open_in (
@@ -386,6 +389,7 @@ static void open_voice (AC97LinkState *s, int index, int freq)
         }
     }
     else {
+printf("closing 0x%X\n", index);
         s->invalid_freq[index] = freq;
         switch (index) {
         case PI_INDEX:
@@ -547,6 +551,7 @@ static void mixer_reset (AC97LinkState *s)
     set_volume (s, AC97_PCM_Out_Volume_Mute, 0x8808);
     set_volume (s, AC97_Record_Gain_Mute, 0x8808);
 
+printf("reset voices\n");
     reset_voices (s, active);
 }
 
@@ -877,6 +882,7 @@ static void nabm_writeb (void *opaque, uint32_t addr, uint32_t val)
         r = &s->bm_regs[GET_BM (index)];
         if (val & CR_RR) {
             reset_bm_regs (s, r);
+printf("reset 0x%X\n", GET_BM(index));
         }
         else {
             r->cr = val & CR_VALID_MASK;

--- a/hw/audio/ac97.c
+++ b/hw/audio/ac97.c
@@ -1161,9 +1161,11 @@ static void transfer_audio (AC97LinkState *s, int index, int elapsed)
             if (r->civ == r->lvi) {
                 dolog ("Underrun civ (%d) == lvi (%d)\n", r->civ, r->lvi);
 
-                new_sr |= SR_LVBCI | SR_DCH | SR_CELV;
+                //new_sr |= SR_LVBCI | SR_DCH | SR_CELV;
                 stop = 1;
                 s->bup_flag = (r->bd.ctl_len & BD_BUP) ? BUP_LAST : 0;
+
+                fetch_bd (s, r);
             }
             else {
                 r->civ = r->piv;

--- a/hw/audio/ac97_int.h
+++ b/hw/audio/ac97_int.h
@@ -64,6 +64,7 @@ typedef struct AC97LinkState {
     SWVoiceIn *voice_pi;
     SWVoiceOut *voice_po;
     SWVoiceIn *voice_mc;
+    SWVoiceOut *voice_so;
     int invalid_freq[LAST_INDEX];
     uint8_t silence[128];
     int bup_flag;


### PR DESCRIPTION
There are currently plans to synchronize analog and digital audio buffers in nxdk. This PR is necessary to support this.

This mostly works around (or fixes) bugs in the existing code.

The integration isn't very clean, but that's already a problem in the original QEMU / XQEMU codebase. So, it's still very different from what a real Xbox would do.

If necessary, I grouped S/PDIF with the PCM output. In the mixer code for example (which isn't present on Xbox).
A more Xbox-focused AC97 implementation can follow in the future.

This PR also gets rid of the confusing "ac97: invalid bm_index(3) in voice_set_active" messages.