### PR TITLE
nv2a: Enable fixed-function sphere map texgen

### DIFF
--- a/hw/xbox/nv2a/nv2a_shaders.c
+++ b/hw/xbox/nv2a/nv2a_shaders.c
@@ -449,7 +449,6 @@ GLSL_DEFINE(sceneAmbientColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_FR_AMB) ".xyz")
                 qstring_append_fmt(body, "  oT%d.%c = r.%c * invM + 0.5;\n",
                                    i, c, c);
                 qstring_append(body, "}\n");
-                assert(false); /* Untested */
                 break;
             case TEXGEN_REFLECTION_MAP:
                 assert(i < 3); /* Channels S,T,R only! */

--- a/hw/xbox/nv2a/nv2a_shaders.c
+++ b/hw/xbox/nv2a/nv2a_shaders.c
@@ -431,7 +431,7 @@ GLSL_DEFINE(sceneAmbientColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_FR_AMB) ".xyz")
                 assert(false); /* Untested */
                 break;
             case TEXGEN_SPHERE_MAP:
-                assert(i < 2);  /* Channels S,T only! */
+                assert(j < 2);  /* Channels S,T only! */
                 qstring_append(body, "{\n");
                 /* FIXME: u, r and m only have to be calculated once */
                 qstring_append(body, "  vec3 u = normalize(tPosition.xyz);\n");
@@ -451,7 +451,7 @@ GLSL_DEFINE(sceneAmbientColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_FR_AMB) ".xyz")
                 qstring_append(body, "}\n");
                 break;
             case TEXGEN_REFLECTION_MAP:
-                assert(i < 3); /* Channels S,T,R only! */
+                assert(j < 3); /* Channels S,T,R only! */
                 qstring_append(body, "{\n");
                 /* FIXME: u and r only have to be calculated once, can share the one from SPHERE_MAP */
                 qstring_append(body, "  vec3 u = normalize(tPosition.xyz);\n");
@@ -461,7 +461,7 @@ GLSL_DEFINE(sceneAmbientColor, GLSL_LTCTXA(NV_IGRAPH_XF_LTCTXA_FR_AMB) ".xyz")
                 qstring_append(body, "}\n");
                 break;
             case TEXGEN_NORMAL_MAP:
-                assert(i < 3); /* Channels S,T,R only! */
+                assert(j < 3); /* Channels S,T,R only! */
                 qstring_append_fmt(body, "oT%d.%c = tNormal.%c;\n",
                                    i, c, c);
                 break;


### PR DESCRIPTION
> Can confirm the previously untested sphere map texgen code in nv2a_shader.c works fine, ...
> Had to also fix assertions wrongly comparing against the texture stage index instead of the channel index.

As posted by @Voxel9 in mborgerson/xemu#13