### PR TITLE
Allow xqemu to be built on macOS Ventura.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,6 @@ case "$(uname -s)" in # adjust compilation option based on platform
         ;;
     Darwin)
         echo 'Compiling for MacOS…'
-        sys_cflags='-march=native'
         sys_opts='--disable-cocoa'
         # necessary to find libffi, which is required by gobject
         export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}/usr/local/opt/libffi/lib/pkgconfig"


### PR DESCRIPTION
When trying to build xqemu, the script fails with this: "ERROR: "cc" either does not exist or does not work". The issue in this case is the '-march=native' flag. Clang will complain that it is an unknown argument.